### PR TITLE
Add repository_path filter to get_all_specifications 

### DIFF
--- a/monolithe/specifications/repositorymanager.py
+++ b/monolithe/specifications/repositorymanager.py
@@ -203,7 +203,7 @@ class RepositoryManager (object):
                 f.write(chunk)
                 f.flush()
 
-        strippedRepoPath = self.repository_path.strip("/")
+        stripped_repository_path = self.repository_path.strip("/")
 
         # reads the content of the archive and generate Specification objects
         with zipfile.ZipFile(archive_path, "r") as archive_content:
@@ -211,7 +211,7 @@ class RepositoryManager (object):
 
                 spec_dir = os.path.split(file_name)[0]
 
-                if not spec_dir.startswith(strippedRepoPath):
+                if not spec_dir.startswith(stripped_repository_path):
                     continue
 
                 spec_name = os.path.split(file_name)[1]

--- a/monolithe/specifications/repositorymanager.py
+++ b/monolithe/specifications/repositorymanager.py
@@ -203,9 +203,16 @@ class RepositoryManager (object):
                 f.write(chunk)
                 f.flush()
 
+        strippedRepoPath = self.repository_path.strip("/")
+
         # reads the content of the archive and generate Specification objects
         with zipfile.ZipFile(archive_path, "r") as archive_content:
             for file_name in archive_content.namelist():
+
+                spec_dir = os.path.split(file_name)[0]
+
+                if not spec_dir.startswith(strippedRepoPath):
+                    continue
 
                 spec_name = os.path.split(file_name)[1]
 


### PR DESCRIPTION
Added check in get_all_specifications(...) to filter out all files not under the repository_path.