### PR TITLE
Removed default value for the build.number in pom.xml

### DIFF
--- a/monolithe/generators/lang/vro/templates/pom.xml.tpl
+++ b/monolithe/generators/lang/vro/templates/pom.xml.tpl
@@ -10,7 +10,6 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <vco.version>6.0.3</vco.version>
-        <build.number>1</build.number>
     </properties>
 
     <repositories>


### PR DESCRIPTION
Removed default value for the build.number property in order for the Maven process on the Bamboo build server to always use the value of the build.number property passed on the command line.