### PR TITLE
Vspk go generator fix and better defaults

### DIFF
--- a/monolithe/generators/lang/go/templates/model.go.tpl
+++ b/monolithe/generators/lang/go/templates/model.go.tpl
@@ -14,14 +14,14 @@ var {{specification.entity_name}}Identity = bambou.Identity {
 // {{specification.entity_name_plural}}List represents a list of {{specification.entity_name_plural}}
 type {{specification.entity_name_plural}}List []*{{specification.entity_name}}
 
-// {{specification.entity_name_plural}}Ancestor is the interface of an ancestor of a {{specification.entity_name}} must implement.
+// {{specification.entity_name_plural}}Ancestor is the interface that an ancestor of a {{specification.entity_name}} must implement.
 // An Ancestor is defined as an entity that has {{specification.entity_name}} as a descendant.
 // An Ancestor can get a list of its child {{specification.entity_name_plural}}, but not necessarily create one.
 type {{specification.entity_name_plural}}Ancestor interface {
     {{specification.entity_name_plural}}(*bambou.FetchingInfo) ({{specification.entity_name_plural}}List, *bambou.Error)
 }
 
-// {{specification.entity_name_plural}}Parent is the interface of a parent of a {{specification.entity_name}} must implement.
+// {{specification.entity_name_plural}}Parent is the interface that a parent of a {{specification.entity_name}} must implement.
 // A Parent is defined as an entity that has {{specification.entity_name}} as a child.
 // A Parent is an Ancestor which can create a {{specification.entity_name}}.
 type {{specification.entity_name_plural}}Parent interface {

--- a/monolithe/generators/lang/go/templates/model.go.tpl
+++ b/monolithe/generators/lang/go/templates/model.go.tpl
@@ -42,8 +42,15 @@ type {{specification.entity_name}} struct {
 func New{{specification.entity_name}}() *{{specification.entity_name}} {
 
     return &{{specification.entity_name}}{
-        {% for attribute, value in attribute_defaults.iteritems() -%}
-        {{attribute}}: {{value}},
+        {% for attribute in specification.attributes -%}
+        {% set field_name = attribute.local_name[0:1].upper() + attribute.local_name[1:] -%}
+        {% if attribute.default_value and attribute.local_type != "list" -%}
+        {% if attribute.local_type == "string" -%}
+        {{ field_name }}: "{{attribute.default_value}}",
+        {% else -%}
+        {{ field_name }}: {{attribute.default_value}},
+        {% endif -%}
+        {% endif -%}
         {% endfor -%}
     }
 }

--- a/monolithe/generators/lang/go/templates/model.go.tpl
+++ b/monolithe/generators/lang/go/templates/model.go.tpl
@@ -60,6 +60,12 @@ func New{{specification.entity_name}}() *{{specification.entity_name}} {
         {% else -%}
         {{ field_name }}: {{attribute.default_value}},
         {% endif -%}
+        {% elif attribute.local_type != "list" -%}
+        {% for def_attribute, def_value in attribute_defaults.iteritems() -%}
+        {% if def_attribute == field_name -%}
+        {{ def_attribute }}: {{ def_value }}, 
+        {% endif -%}
+        {% endfor -%}
         {% endif -%}
         {% endfor -%}
     }


### PR DESCRIPTION
Couple of fixes for the Go VSPK:
- No CreateEntity method on entities that do not support it (for instance: No CreateContainer on a subnet, a container can not be created in a subnet)
- Changing of the Ancestor interface for each entity: 
  - it had a CreateEntities method, which never exists (all CreateEntity used the single form of the Entity name). As such, the Ancestor interface was useless
  - Switched to two interfaces:
    - EntitiesAncestor: only has the GET request method (get a list of Entity as a requirement - An ancestor is any Object that can get a list of an Entity.)
    - EntitiesParent: has both the GET request method and the POST request (create an Entity as a requirement. - A parent is an ancestor that can also create an Entity)
  - The idea behind this is mimicking life: an Ancestor can get all Entities in the hierarchy below it, but it can not create an Entity. A grandparent is an ancestor if a grandchild: It can get a list of it grandchildren, but it can not create a grandchild. A parent is able to get a list of its own children and is also capable of creating a new child.
- Clean up the way we do the default values of entities, for each attribute of an entity:
  - If there is a default value for an attribute of an entity in the vsd-api-specifications, that default value is set on entity creation 
  - Else, if there is a default value in the vspkgenerator attribute_defaults file, that value is used.

This would clean up the Go VSPK and improve the usability.