### PR TITLE
Adding support for certificate based auth

### DIFF
--- a/monolithe/generators/lang/go/templates/session.go.tpl
+++ b/monolithe/generators/lang/go/templates/session.go.tpl
@@ -6,24 +6,36 @@ import (
     "github.com/nuagenetworks/go-bambou/bambou"
     "fmt"
     "strings"
+    "crypto/tls"
 )
 
 var (
-    _URLPostfix string
+    urlpostfix string
 )
 
-// Returns a new Session
+// Returns a new Session -- authentication using username + password
 func NewSession(username, password, organization, url string) (*bambou.Session, *{{root_api|capitalize}}) {
 
     root := New{{root_api|capitalize}}()
-    url += _URLPostfix
+    url += urlpostfix
 
     session := bambou.NewSession(username, password, organization, url, root)
 
     return session, root
 }
 
+// Returns a new Session -- authentication using X509 certificate.
+func NewX509Session(cert *tls.Certificate, url string) (*bambou.Session, *{{root_api|capitalize}}) {
+
+    root := New{{root_api|capitalize}}()
+    url += urlpostfix
+
+    session := bambou.NewX509Session(cert, url, root)
+
+    return session, root
+}
+
 func init() {
 
-    _URLPostfix = "/" + SDKAPIPrefix + "/v" + strings.Replace(fmt.Sprintf("%.1f", SDKAPIVersion), ".", "_", 100)
+    urlpostfix = "/" + SDKAPIPrefix + "/v" + strings.Replace(fmt.Sprintf("%.1f", SDKAPIVersion), ".", "_", 100)
 }


### PR DESCRIPTION
Tested this with the current go-bambou and the one from nuagenetworks/go-bambou#4 , both work fine, so this should be merged and used for VSPK 4.0.7