### PR TITLE
Use Monolithe's --generation-version argument for generated vspk-java

### DIFF
--- a/monolithe/generators/lang/java/writers/apiversionwriter.py
+++ b/monolithe/generators/lang/java/writers/apiversionwriter.py
@@ -51,6 +51,7 @@ class APIVersionWriter(TemplateFileWriter):
         self.api_prefix = api_info["prefix"]
 
         self.monolithe_config = monolithe_config
+        self.library_version = self.monolithe_config.get_option("version", "transformer")
         self._output = self.monolithe_config.get_option("output", "transformer")
         self._name = self.monolithe_config.get_option("name", "transformer")
         self._class_prefix = ""
@@ -76,12 +77,6 @@ class APIVersionWriter(TemplateFileWriter):
         path = "%s/java/__attributes_defaults/attrs_types.ini" % self._output
         self.attrs_types.optionxform = str
         self.attrs_types.read(path)
-
-        library_info = RawConfigParser()
-        path = "%s/java/__attributes_defaults/library.ini" % self._output
-        library_info.optionxform = str
-        library_info.read(path)
-        self.library_version = library_info.get(self.api_version, "libraryVersion")
 
         with open("%s/java/__code_header" % self._output, "r") as f:
             self.header_content = f.read()


### PR DESCRIPTION
version