### PR TITLE
vspk js generator - handle list, integer, float, generic enum classes

### DIFF
--- a/monolithe/generators/lang/javascript/templates/entity.js.tpl
+++ b/monolithe/generators/lang/javascript/templates/entity.js.tpl
@@ -5,6 +5,11 @@ import {{ class_prefix }}{{ superclass_name}} from '{% if superclass_name == "Ab
 {%- set import_str %}import { {% for attribute in enum_attrs_to_import %}{% if loop.index0 > 0 %}, {% endif %}{{ class_prefix }}{{ specification.entity_name }}{{ attribute.name[0].upper() + attribute.name[1:] }}Enum{% endfor %} } from './enums';{%- endset %}
 {{ import_str|wordwrap(96,false,'\n    ')}}
 {%- endif %}
+{%- if generic_enum_attributes_to_import and generic_enum_attributes_to_import|length > 0 %}
+{%- set import_str %}import { {% for attr in generic_enum_attributes_to_import %}{% if loop.index0 > 0 %}, {% endif %}{{ class_prefix }}{{ attr[0].upper() + attr[1:] }}Enum{% endfor %} } from './enums';{%- endset %}
+{{ import_str|wordwrap(96,false,'\n    ')}}
+{%- endif %}
+
 
 /* Represents {{ specification.entity_name }} entity
 {% if specification.description %}   {{ specification.description|wordwrap(97,false,'\n   ')}}{{'\n'}}{% endif -%}
@@ -15,7 +20,7 @@ export default class {{ class_prefix }}{{ specification.entity_name }} extends {
         this.defineProperties({
         {%- for attribute in specification.attributes %}
             {% set is_enum = attribute.allowed_choices and attribute.allowed_choices|length > 0  -%}
-            {{ attribute.name }}: {% if attribute.default_value %}{% if attribute.local_type == "string" %}'{{ attribute.default_value }}'{% else %}{% if is_enum  %}{{ class_prefix }}{{ specification.entity_name }}{{ attribute.name[0].upper() + attribute.name[1:] }}Enum.{% endif %}{{ attribute.default_value }}{% if is_enum  %}.name{% endif %}{% endif %}{% else %}null{% endif %},
+            {{ attribute.name }}: {% if attribute.default_value %}{% if attribute.local_type == "string" %}'{{ attribute.default_value }}'{% else %}{% if is_enum  %}{{ class_prefix }}{% set attr_name %}{% if attribute.name not in  generic_enum_attributes%}{{ attribute.name }}{% else %}{{ generic_enum_attributes[attribute.name].name }}{% endif %}{% endset %}{% if attribute.name not in  generic_enum_attributes%}{{ specification.entity_name }}{% endif %}{{ attr_name[0].upper() + attr_name[1:] }}Enum.{% endif %}{{ attribute.default_value }}{% if is_enum  %}.name{% endif %}{% endif %}{% else %}null{% endif %},
         {%- endfor %}
         });
     }
@@ -32,7 +37,7 @@ export default class {{ class_prefix }}{{ specification.entity_name }} extends {
             isEditable: false{% endif %}{% if attribute.orderable %},
             canOrder: true{% endif %}{% if attribute.filterable %},
             canSearch: true{% endif %}{% if attribute.allowed_choices and attribute.allowed_choices|length > 0  %},
-            {%- set choices_str %}[{% for choice in attribute.allowed_choices %}{% if loop.index0 > 0 %}, {% endif %}{{ class_prefix }}{{ specification.entity_name }}{{ attribute.name[0].upper() + attribute.name[1:] }}Enum.{{choice}}{% endfor %}]{%- endset %}
+            {%- set choices_str %}[{% for choice in attribute.allowed_choices %}{% if loop.index0 > 0 %}, {% endif %}{{ class_prefix }}{% set attr_name %}{% if attribute.name not in  generic_enum_attributes%}{{ attribute.name }}{% else %}{{ generic_enum_attributes[attribute.name].name }}{% endif %}{% endset %}{% if attribute.name not in  generic_enum_attributes%}{{ specification.entity_name }}{% endif %}{{ attr_name[0].upper() + attr_name[1:] }}Enum.{{choice}}{% endfor %}]{%- endset %}
             choices: {{choices_str|wordwrap(80,false,'\n                ')}}{% endif %},{% if attribute.local_type == "list" %}
             subType: {{ class_prefix }}Attribute.ATTR_TYPE_{% if attribute.subtype == "integer" %}INTEGER{% elif attribute.subtype == "float" %}FLOAT{% elif attribute.subtype == "boolean" %}BOOLEAN{% elif attribute.subtype == "enum" and attribute.allowed_choices and attribute.allowed_choices|length > 0 %}ENUM{% else %}STRING{% endif %},{% endif %}
             userlabel: '{{ attribute.userlabel }}',
@@ -46,4 +51,3 @@ export default class {{ class_prefix }}{{ specification.entity_name }} extends {
 }
 
 ServiceClassRegistry.register({{ class_prefix }}{{ specification.entity_name }});
-

--- a/monolithe/generators/lang/javascript/templates/entity.js.tpl
+++ b/monolithe/generators/lang/javascript/templates/entity.js.tpl
@@ -51,3 +51,4 @@ export default class {{ class_prefix }}{{ specification.entity_name }} extends {
 }
 
 ServiceClassRegistry.register({{ class_prefix }}{{ specification.entity_name }});
+

--- a/monolithe/generators/lang/javascript/templates/entity.js.tpl
+++ b/monolithe/generators/lang/javascript/templates/entity.js.tpl
@@ -25,7 +25,7 @@ export default class {{ class_prefix }}{{ specification.entity_name }} extends {
         {%- for attribute in specification.attributes %}
         {{ attribute.name }}: new {{ class_prefix }}Attribute({
             localName: '{{ attribute.name }}',
-            attributeType: {{ class_prefix }}Attribute.ATTR_TYPE_{% if attribute.local_type == "string" %}STRING{% elif attribute.local_type == "boolean" %}BOOLEAN{% elif attribute.allowed_choices and attribute.allowed_choices|length > 0 %}ENUM{% else %}NUMBER{% endif %}{% if attribute.required %},
+            attributeType: {{ class_prefix }}Attribute.ATTR_TYPE_{% if attribute.local_type == "integer" %}INTEGER{% elif attribute.local_type == "float" %}FLOAT{% elif attribute.local_type == "list" %}LIST{% elif attribute.local_type == "boolean" %}BOOLEAN{% elif attribute.local_type == "enum" and attribute.allowed_choices and attribute.allowed_choices|length > 0 %}ENUM{% else %}STRING{% endif %}{% if attribute.required %},
             isRequired: true{% endif %}{% if attribute.unique %},
             isUnique: true{% endif %}{% if attribute.creation_only %},
             isReadOnly: true{% endif %}{% if attribute.read_only %},
@@ -33,7 +33,8 @@ export default class {{ class_prefix }}{{ specification.entity_name }} extends {
             canOrder: true{% endif %}{% if attribute.filterable %},
             canSearch: true{% endif %}{% if attribute.allowed_choices and attribute.allowed_choices|length > 0  %},
             {%- set choices_str %}[{% for choice in attribute.allowed_choices %}{% if loop.index0 > 0 %}, {% endif %}{{ class_prefix }}{{ specification.entity_name }}{{ attribute.name[0].upper() + attribute.name[1:] }}Enum.{{choice}}{% endfor %}]{%- endset %}
-            choices: {{choices_str|wordwrap(80,false,'\n                ')}}{% endif %},
+            choices: {{choices_str|wordwrap(80,false,'\n                ')}}{% endif %},{% if attribute.local_type == "list" %}
+            subType: {{ class_prefix }}Attribute.ATTR_TYPE_{% if attribute.subtype == "integer" %}INTEGER{% elif attribute.subtype == "float" %}FLOAT{% elif attribute.subtype == "boolean" %}BOOLEAN{% elif attribute.subtype == "enum" and attribute.allowed_choices and attribute.allowed_choices|length > 0 %}ENUM{% else %}STRING{% endif %},{% endif %}
             userlabel: '{{ attribute.userlabel }}',
         }),
         {%- endfor %}

--- a/monolithe/generators/lang/javascript/writers/apiversionwriter.py
+++ b/monolithe/generators/lang/javascript/writers/apiversionwriter.py
@@ -1,9 +1,16 @@
 from monolithe.generators.lib import TemplateFileWriter
+from monolithe.specifications import SpecificationAttribute
 import os
 import shutil
 
-base_attrs = ['entityScope', 'externalID', 'lastUpdatedBy'];
-named_entity_attrs = ['name', 'description'];
+base_attrs = ['entityScope', 'externalID', 'lastUpdatedBy']
+named_entity_attrs = ['name', 'description']
+iptype_enum_attr = SpecificationAttribute()
+iptype_enum_attr.name = 'IPType'
+iptype_enum_attr.allowed_choices = ['IPv4', 'IPv6', 'DUALSTACK', 'IPv4Network', 'IPv6Network']
+enabled_enum_attr = SpecificationAttribute()
+enabled_enum_attr.name = 'enabled'
+enabled_enum_attr.allowed_choices = ['DISABLED', 'ENABLED', 'INHERITED']
 
 
 class APIVersionWriter(TemplateFileWriter):
@@ -38,6 +45,8 @@ class APIVersionWriter(TemplateFileWriter):
         for rest_name, specification in specifications.iteritems():
             self._write_model(specification=specification)
 
+        self._write_generic_enums()
+        
         self.write(destination = self.model_directory,
             filename="index.js",
             template_name="model_index.js.tpl",
@@ -84,8 +93,24 @@ class APIVersionWriter(TemplateFileWriter):
         specification.attributes = [attribute for attribute in specification.attributes if (attribute.name not in base_attrs and (not isNamedEntity or attribute.name not in named_entity_attrs))]
 
         enum_attributes=[attribute for attribute in specification.attributes if attribute.allowed_choices]
-            
+        
         self._write_enums(entity_name=specification.entity_name, attributes=enum_attributes)
+        
+        enum_attrs_to_import = enum_attributes[:]
+        generic_enum_attributes = {}
+        generic_enum_attributes_to_import = []
+
+        for attr in enum_attributes:
+            if set(attr.allowed_choices) & set(iptype_enum_attr.allowed_choices):
+                generic_enum_attributes[attr.name] = iptype_enum_attr
+                enum_attrs_to_import.remove(attr)
+                generic_enum_attributes_to_import.append(iptype_enum_attr.name)
+                
+            if set(attr.allowed_choices) & set(enabled_enum_attr.allowed_choices):
+                generic_enum_attributes[attr.name] = enabled_enum_attr
+                enum_attrs_to_import.remove(attr)
+                generic_enum_attributes_to_import.append(enabled_enum_attr.name)
+
         
         self.write(destination = self.model_directory,
                     filename = filename,
@@ -93,7 +118,9 @@ class APIVersionWriter(TemplateFileWriter):
                     class_prefix = self._class_prefix,
                     specification = specification,
                     superclass_name = superclass_name,
-                    enum_attrs_to_import = enum_attributes)
+                    enum_attrs_to_import = enum_attrs_to_import,
+                    generic_enum_attributes = generic_enum_attributes,
+                    generic_enum_attributes_to_import = set(generic_enum_attributes_to_import))
 
     def _isNamedEntity(self, attributes):
         hasName = False
@@ -119,3 +146,10 @@ class APIVersionWriter(TemplateFileWriter):
                         class_prefix = self._class_prefix,
                         enum_name = enum_name,
                         allowed_choices = set(attribute.allowed_choices))
+
+    def _write_generic_enums(self):
+        """ This method generates generic enum classes.
+        """
+
+        generic_enums = [iptype_enum_attr, enabled_enum_attr]
+        self._write_enums(entity_name='', attributes=generic_enums)


### PR DESCRIPTION
Generated generic enum class NUIPTypeEnum.js
````
import { Enum } from 'enumify';

class NUIPTypeEnum extends Enum {}
NUIPTypeEnum.initEnum(['IPv6Network', 'IPv4Network', 'DUALSTACK', 'IPv4', 'IPv6']);

export default NUIPTypeEnum;

````
Generated generic enum class NUEnabledEnum.js
````
import { Enum } from 'enumify';

class NUEnabledEnum extends Enum {}
NUEnabledEnum.initEnum(['DISABLED', 'ENABLED', 'INHERITED']);

export default NUEnabledEnum;

````
Generated entity class NUSubnet.js
````
import NUAttribute from 'service/NUAttribute';
import ServiceClassRegistry from 'service/ServiceClassRegistry';
import NUAbstractNamedEntity from './abstract/NUAbstractNamedEntity';
import { NUSubnetDefaultActionEnum, NUSubnetResourceTypeEnum, NUSubnetEntityStateEnum } from
    './enums';
import { NUEnabledEnum, NUIPTypeEnum } from './enums';


/* Represents Subnet entity
   This is the definition of a subnet associated with a Zone.
*/
export default class NUSubnet extends NUAbstractNamedEntity {
    constructor(...args) {
        super(...args);
        this.defineProperties({
            PATEnabled: null,
            DHCPRelayStatus: null,
            DPI: NUEnabledEnum.INHERITED.name,
            IPType: null,
            IPv6Address: null,
            IPv6Gateway: null,
            maintenanceMode: null,
            gateway: null,
            gatewayMACAddress: null,
            accessRestrictionEnabled: false,
            address: null,
            advertise: true,
            defaultAction: null,
            templateID: null,
            serviceID: null,
            resourceType: NUSubnetResourceTypeEnum.STANDARD.name,
            netmask: null,
            vnId: null,
            encryption: null,
            underlay: null,
            underlayEnabled: null,
            entityState: null,
            policyGroupID: null,
            routeDistinguisher: null,
            routeTarget: null,
            splitSubnet: null,
            proxyARP: null,
            useGlobalMAC: null,
            associatedMulticastChannelMapID: null,
            associatedSharedNetworkResourceID: null,
            public: null,
            multicast: null,
            dynamicIpv6Address: false,
        });
    }

    static attributeDescriptors = {
        ...NUAbstractNamedEntity.attributeDescriptors,
        PATEnabled: new NUAttribute({
            localName: 'PATEnabled',
            attributeType: NUAttribute.ATTR_TYPE_ENUM,
            canSearch: true,
            choices: [NUEnabledEnum.DISABLED, NUEnabledEnum.ENABLED, NUEnabledEnum.INHERITED],
            userlabel: 'PAT Enabled',
        }),
        DHCPRelayStatus: new NUAttribute({
            localName: 'DHCPRelayStatus',
            attributeType: NUAttribute.ATTR_TYPE_ENUM,
            canOrder: true,
            canSearch: true,
            choices: [NUEnabledEnum.DISABLED, NUEnabledEnum.ENABLED],
            userlabel: 'DHCP Relay Status',
        }),
        DPI: new NUAttribute({
            localName: 'DPI',
            attributeType: NUAttribute.ATTR_TYPE_ENUM,
            canOrder: true,
            canSearch: true,
            choices: [NUEnabledEnum.DISABLED, NUEnabledEnum.ENABLED, NUEnabledEnum.INHERITED],
            userlabel: 'DPI',
        }),
        IPType: new NUAttribute({
            localName: 'IPType',
            attributeType: NUAttribute.ATTR_TYPE_ENUM,
            canOrder: true,
            canSearch: true,
            choices: [NUIPTypeEnum.DUALSTACK, NUIPTypeEnum.IPV4],
            userlabel: 'IP Type',
        }),
        IPv6Address: new NUAttribute({
            localName: 'IPv6Address',
            attributeType: NUAttribute.ATTR_TYPE_STRING,
            canOrder: true,
            canSearch: true,
            userlabel: 'IPv6 Address',
        }),
        IPv6Gateway: new NUAttribute({
            localName: 'IPv6Gateway',
            attributeType: NUAttribute.ATTR_TYPE_STRING,
            canOrder: true,
            canSearch: true,
            userlabel: 'IPv6 Gateway',
        }),
        maintenanceMode: new NUAttribute({
            localName: 'maintenanceMode',
            attributeType: NUAttribute.ATTR_TYPE_ENUM,
            choices: [NUEnabledEnum.DISABLED, NUEnabledEnum.ENABLED, NUEnabledEnum.ENABLED_INHERITED],
            userlabel: 'Maintenance Mode',
        }),
        gateway: new NUAttribute({
            localName: 'gateway',
            attributeType: NUAttribute.ATTR_TYPE_STRING,
            canOrder: true,
            canSearch: true,
            userlabel: 'Gateway',
        }),
        gatewayMACAddress: new NUAttribute({
            localName: 'gatewayMACAddress',
            attributeType: NUAttribute.ATTR_TYPE_STRING,
            userlabel: 'Gateway MAC Address',
        }),
        accessRestrictionEnabled: new NUAttribute({
            localName: 'accessRestrictionEnabled',
            attributeType: NUAttribute.ATTR_TYPE_BOOLEAN,
            canOrder: true,
            canSearch: true,
            userlabel: 'Access  Restricted',
        }),
        address: new NUAttribute({
            localName: 'address',
            attributeType: NUAttribute.ATTR_TYPE_STRING,
            canOrder: true,
            canSearch: true,
            userlabel: 'Address',
        }),
        advertise: new NUAttribute({
            localName: 'advertise',
            attributeType: NUAttribute.ATTR_TYPE_BOOLEAN,
            isReadOnly: true,
            canOrder: true,
            canSearch: true,
            userlabel: 'Advertise',
        }),
        defaultAction: new NUAttribute({
            localName: 'defaultAction',
            attributeType: NUAttribute.ATTR_TYPE_ENUM,
            canOrder: true,
            canSearch: true,
            choices: [NUSubnetDefaultActionEnum.DROP_TRAFFIC, NUSubnetDefaultActionEnum.USE_UNDERLAY],
            userlabel: 'Default Action',
        }),
        templateID: new NUAttribute({
            localName: 'templateID',
            attributeType: NUAttribute.ATTR_TYPE_STRING,
            userlabel: 'Template ID',
        }),
        serviceID: new NUAttribute({
            localName: 'serviceID',
            attributeType: NUAttribute.ATTR_TYPE_INTEGER,
            canOrder: true,
            canSearch: true,
            userlabel: 'Service ID',
        }),
        resourceType: new NUAttribute({
            localName: 'resourceType',
            attributeType: NUAttribute.ATTR_TYPE_ENUM,
            canOrder: true,
            canSearch: true,
            choices: [NUSubnetResourceTypeEnum.FLOATING, NUSubnetResourceTypeEnum.NSG_VNF,
                NUSubnetResourceTypeEnum.PUBLIC, NUSubnetResourceTypeEnum.STANDARD],
            userlabel: 'Resource Type',
        }),
        netmask: new NUAttribute({
            localName: 'netmask',
            attributeType: NUAttribute.ATTR_TYPE_STRING,
            canOrder: true,
            canSearch: true,
            userlabel: 'Netmask',
        }),
        vnId: new NUAttribute({
            localName: 'vnId',
            attributeType: NUAttribute.ATTR_TYPE_INTEGER,
            userlabel: 'Vn Id',
        }),
        encryption: new NUAttribute({
            localName: 'encryption',
            attributeType: NUAttribute.ATTR_TYPE_ENUM,
            canSearch: true,
            choices: [NUEnabledEnum.DISABLED, NUEnabledEnum.ENABLED, NUEnabledEnum.INHERITED],
            userlabel: 'Encryption',
        }),
        underlay: new NUAttribute({
            localName: 'underlay',
            attributeType: NUAttribute.ATTR_TYPE_BOOLEAN,
            canSearch: true,
            userlabel: 'Underlay',
        }),
        underlayEnabled: new NUAttribute({
            localName: 'underlayEnabled',
            attributeType: NUAttribute.ATTR_TYPE_ENUM,
            canSearch: true,
            choices: [NUEnabledEnum.DISABLED, NUEnabledEnum.ENABLED, NUEnabledEnum.INHERITED],
            userlabel: 'Underlay Enabled',
        }),
        entityState: new NUAttribute({
            localName: 'entityState',
            attributeType: NUAttribute.ATTR_TYPE_ENUM,
            choices: [NUSubnetEntityStateEnum.MARKED_FOR_DELETION,
                NUSubnetEntityStateEnum.UNDER_CONSTRUCTION],
            userlabel: 'Entity State',
        }),
        policyGroupID: new NUAttribute({
            localName: 'policyGroupID',
            attributeType: NUAttribute.ATTR_TYPE_INTEGER,
            canSearch: true,
            userlabel: 'Policy Group ID',
        }),
        routeDistinguisher: new NUAttribute({
            localName: 'routeDistinguisher',
            attributeType: NUAttribute.ATTR_TYPE_STRING,
            canOrder: true,
            canSearch: true,
            userlabel: 'Route Distinguisher',
        }),
        routeTarget: new NUAttribute({
            localName: 'routeTarget',
            attributeType: NUAttribute.ATTR_TYPE_STRING,
            canOrder: true,
            canSearch: true,
            userlabel: 'Route Target',
        }),
        splitSubnet: new NUAttribute({
            localName: 'splitSubnet',
            attributeType: NUAttribute.ATTR_TYPE_BOOLEAN,
            canOrder: true,
            canSearch: true,
            userlabel: 'Split Subnet',
        }),
        proxyARP: new NUAttribute({
            localName: 'proxyARP',
            attributeType: NUAttribute.ATTR_TYPE_BOOLEAN,
            canOrder: true,
            canSearch: true,
            userlabel: 'Proxy ARP',
        }),
        useGlobalMAC: new NUAttribute({
            localName: 'useGlobalMAC',
            attributeType: NUAttribute.ATTR_TYPE_ENUM,
            canOrder: true,
            canSearch: true,
            choices: [NUEnabledEnum.DISABLED, NUEnabledEnum.ENABLED],
            userlabel: 'Use Global MAC',
        }),
        associatedMulticastChannelMapID: new NUAttribute({
            localName: 'associatedMulticastChannelMapID',
            attributeType: NUAttribute.ATTR_TYPE_STRING,
            userlabel: 'Associated Multicast Chan',
        }),
        associatedSharedNetworkResourceID: new NUAttribute({
            localName: 'associatedSharedNetworkResourceID',
            attributeType: NUAttribute.ATTR_TYPE_STRING,
            userlabel: 'Associated Shared Network',
        }),
        public: new NUAttribute({
            localName: 'public',
            attributeType: NUAttribute.ATTR_TYPE_BOOLEAN,
            userlabel: 'Public',
        }),
        multicast: new NUAttribute({
            localName: 'multicast',
            attributeType: NUAttribute.ATTR_TYPE_ENUM,
            canSearch: true,
            choices: [NUEnabledEnum.DISABLED, NUEnabledEnum.ENABLED, NUEnabledEnum.INHERITED],
            userlabel: 'Multicast',
        }),
        dynamicIpv6Address: new NUAttribute({
            localName: 'dynamicIpv6Address',
            attributeType: NUAttribute.ATTR_TYPE_BOOLEAN,
            canOrder: true,
            canSearch: true,
            userlabel: 'Dynamic Ipv6 Address',
        }),
    }

    get RESTName() {
        return 'subnets';
    }
}

ServiceClassRegistry.register(NUSubnet);

````