### PR TITLE
generate getAllowedJobCommands

### DIFF
--- a/monolithe/generators/lang/javascript/templates/entity.js.tpl
+++ b/monolithe/generators/lang/javascript/templates/entity.js.tpl
@@ -9,6 +9,9 @@ import {{ class_prefix }}{{ superclass_name}} from '{% if superclass_name == "Ab
 {%- set import_str %}import { {% for attr in generic_enum_attributes_to_import %}{% if loop.index0 > 0 %}, {% endif %}{{ class_prefix }}{{ attr[0].upper() + attr[1:] }}Enum{% endfor %} } from '@/enums';{%- endset %}
 {{ import_str|wordwrap(96,false,'\n    ')}}
 {%- endif %}
+{%- if specification.allowed_job_commands %}
+import {{ class_prefix }}JobCommandEnum from './enums';
+{%- endif %}
 
 
 /* Represents {{ specification.entity_name }} entity
@@ -69,6 +72,14 @@ export default class {{ class_prefix }}{{ specification.entity_name }} extends {
     getClassName() {
         return {{ class_prefix }}{{ specification.entity_name }}.getClassName();
     }
+    
+    {%- if specification.allowed_job_commands %}
+
+    getAllowedJobCommands() {
+        {%- set commands_str %}[{% for command in specification.allowed_job_commands %}{% if loop.index0 > 0 %}, {% endif %}{{ class_prefix }}JobCommandEnum.{{command}}{% endfor %}];{%- endset %}
+        return {{commands_str|wordwrap(80,false,'\n                ')}}
+    }
+    {%- endif %}
 }
 
 ServiceClassRegistry.register({{ class_prefix }}{{ specification.entity_name }});

--- a/monolithe/generators/lang/javascript/templates/entity.js.tpl
+++ b/monolithe/generators/lang/javascript/templates/entity.js.tpl
@@ -61,6 +61,11 @@ export default class {{ class_prefix }}{{ specification.entity_name }} extends {
         return '{{ class_prefix }}{{ specification.entity_name }}';
     }
     
+    static getAllowedJobCommands() {
+        {%- set commands_str %}{% if specification.allowed_job_commands %}[{% for command in specification.allowed_job_commands %}{% if loop.index0 > 0 %}, {% endif %}{{ class_prefix }}JobCommandEnum.{{command}}{% endfor %}]{% else %}[]{% endif %};{%- endset %}
+        return {{commands_str|wordwrap(80,false,'\n                ')}}
+    }
+    
     get RESTName() {
         return '{{ specification.rest_name }}';
     }
@@ -72,14 +77,10 @@ export default class {{ class_prefix }}{{ specification.entity_name }} extends {
     getClassName() {
         return {{ class_prefix }}{{ specification.entity_name }}.getClassName();
     }
-    
-    {%- if specification.allowed_job_commands %}
 
     getAllowedJobCommands() {
-        {%- set commands_str %}[{% for command in specification.allowed_job_commands %}{% if loop.index0 > 0 %}, {% endif %}{{ class_prefix }}JobCommandEnum.{{command}}{% endfor %}];{%- endset %}
-        return {{commands_str|wordwrap(80,false,'\n                ')}}
+        return {{ class_prefix }}{{ specification.entity_name }}.getAllowedJobCommands();
     }
-    {%- endif %}
 }
 
 ServiceClassRegistry.register({{ class_prefix }}{{ specification.entity_name }});

--- a/monolithe/generators/lang/javascript/writers/apiversionwriter.py
+++ b/monolithe/generators/lang/javascript/writers/apiversionwriter.py
@@ -74,6 +74,8 @@ class APIVersionWriter(TemplateFileWriter):
         """
         self.enum_list = []
         self.model_list = []
+        self.job_commands = filter(lambda attr: attr.name == 'command', specifications.get("job").attributes)[0].allowed_choices
+        #Printer.log("job_commands: %s" % (self.job_commands))
             
         self._write_abstract_named_entity()
         
@@ -147,6 +149,11 @@ class APIVersionWriter(TemplateFileWriter):
     def _write_model(self, specification):
         """ This method writes the ouput for a particular specification.
         """
+        
+        if specification.allowed_job_commands and not (set(specification.allowed_job_commands).issubset(self.job_commands)):
+            raise Exception("Invalid allowed_job_commands %s specified in entity %s" % (specification.allowed_job_commands, specification.entity_name))
+            
+        
         filename = "%s%s.js" % (self._class_prefix, specification.entity_name)
 
         self.model_list.append("%s%s" %(self._class_prefix, specification.entity_name))


### PR DESCRIPTION
Sample generated model.js:
Entity without any job command
```
import NUAttribute from 'service/NUAttribute';
import ServiceClassRegistry from 'service/ServiceClassRegistry';
import NUAbstractNamedEntity from './abstract/NUAbstractNamedEntity';
import { NUZFBAutoAssignmentZFBMatchAttributeEnum } from './enums';


/* Represents ZFBAutoAssignment entity
   ZFB Enterprise Auto Assignment
*/
export default class NUZFBAutoAssignment extends NUAbstractNamedEntity {
    constructor(...args) {
        super(...args);
        this.defineProperties({
            ZFBMatchAttribute: null,
            ZFBMatchAttributeValues: null,
            priority: null,
            associatedEnterpriseID: null,
            associatedEnterpriseName: null,
        });
    }

    static entityDescriptor = {
        description: `ZFB Enterprise Auto Assignment `,
        userlabel: `Enterprise Auto Assignment`,
    }

    static attributeDescriptors = {
        ...NUAbstractNamedEntity.attributeDescriptors,
        ZFBMatchAttribute: new NUAttribute({
            localName: 'ZFBMatchAttribute',
            attributeType: NUAttribute.ATTR_TYPE_ENUM,
            description: `Attribute to auto match on`,
            canOrder: true,
            canSearch: true,
            choices: [NUZFBAutoAssignmentZFBMatchAttributeEnum.HOSTNAME,
                NUZFBAutoAssignmentZFBMatchAttributeEnum.IP_ADDRESS,
                NUZFBAutoAssignmentZFBMatchAttributeEnum.MAC_ADDRESS,
                NUZFBAutoAssignmentZFBMatchAttributeEnum.NSGATEWAY_ID,
                NUZFBAutoAssignmentZFBMatchAttributeEnum.SERIAL_NUMBER],
            userlabel: `ZFB Match Attribute`,
        }),
        ZFBMatchAttributeValues: new NUAttribute({
            localName: 'ZFBMatchAttributeValues',
            attributeType: NUAttribute.ATTR_TYPE_LIST,
            description: `Array of values to match on`,
            canOrder: true,
            canSearch: true,
            subType: NUAttribute.ATTR_TYPE_STRING,
            userlabel: `ZFB Match Attribute Values`,
        }),
        priority: new NUAttribute({
            localName: 'priority',
            attributeType: NUAttribute.ATTR_TYPE_INTEGER,
            description: `Priority of the Auto Assignment`,
            isRequired: true,
            canOrder: true,
            canSearch: true,
            userlabel: `Priority`,
        }),
        associatedEnterpriseID: new NUAttribute({
            localName: 'associatedEnterpriseID',
            attributeType: NUAttribute.ATTR_TYPE_STRING,
            description: `Associated Enterprise ID`,
            userlabel: `Associated Enterprise ID`,
        }),
        associatedEnterpriseName: new NUAttribute({
            localName: 'associatedEnterpriseName',
            attributeType: NUAttribute.ATTR_TYPE_STRING,
            description: `The name of the associated Enterprise`,
            userlabel: `Associated Enterprise Name`,
        }),
    }

    static getClassName() {
        return 'NUZFBAutoAssignment';
    }
    
    static getAllowedJobCommands() {
        return [];
    }
    
    get RESTName() {
        return 'zfbautoassignment';
    }
    
    get resourceName() {
        return 'zfbautoassignments';
    }
    
    getClassName() {
        return NUZFBAutoAssignment.getClassName();
    }

    getAllowedJobCommands() {
        return NUZFBAutoAssignment.getAllowedJobCommands();
    }
}

ServiceClassRegistry.register(NUZFBAutoAssignment);
```

Entity with job commands:
```
import NUAttribute from 'service/NUAttribute';
import ServiceClassRegistry from 'service/ServiceClassRegistry';
import NUAbstractNamedEntity from './abstract/NUAbstractNamedEntity';
import { NUVNFTaskStateEnum, NUVNFAllowedActionsEnum, NUVNFStatusEnum, NUVNFTypeEnum } from
    './enums';
import NUJobCommandEnum from './enums';


/* Represents VNF entity
   Represent a VNF instance
*/
export default class NUVNF extends NUAbstractNamedEntity {
    constructor(...args) {
        super(...args);
        this.defineProperties({
            VNFDescriptorID: null,
            VNFDescriptorName: null,
            CPUCount: null,
            NSGName: null,
            NSGSystemID: null,
            NSGatewayID: null,
            taskState: null,
            lastKnownError: null,
            memoryMB: null,
            vendor: null,
            metadataID: null,
            allowedActions: null,
            enterpriseID: null,
            isAttachedToDescriptor: true,
            associatedVNFMetadataID: null,
            associatedVNFThresholdPolicyID: null,
            status: null,
            storageGB: null,
            type: null,
        });
    }

    static entityDescriptor = {
        description: `Represent a VNF instance`,
        userlabel: `VNF`,
    }

    static attributeDescriptors = {
        ...NUAbstractNamedEntity.attributeDescriptors,
        VNFDescriptorID: new NUAttribute({
            localName: 'VNFDescriptorID',
            attributeType: NUAttribute.ATTR_TYPE_STRING,
            description: `The ID of VNF Descriptor from which VNF to be created. This is required on creation and can be removed on moidification of VNF instance.`,
            canSearch: true,
            userlabel: `VNF Descriptor`,
        }),
        VNFDescriptorName: new NUAttribute({
            localName: 'VNFDescriptorName',
            attributeType: NUAttribute.ATTR_TYPE_STRING,
            description: `The Name of VNF Descriptor from which this VNF instance is created.`,
            userlabel: `VNF Descriptor`,
        }),
        CPUCount: new NUAttribute({
            localName: 'CPUCount',
            attributeType: NUAttribute.ATTR_TYPE_INTEGER,
            description: `Number of CPUs to be allocated for this VNF instance`,
            canOrder: true,
            canSearch: true,
            userlabel: `CPU Count`,
        }),
        NSGName: new NUAttribute({
            localName: 'NSGName',
            attributeType: NUAttribute.ATTR_TYPE_STRING,
            description: `The NSG name where VNF is deployed`,
            userlabel: `NSG Name`,
        }),
        NSGSystemID: new NUAttribute({
            localName: 'NSGSystemID',
            attributeType: NUAttribute.ATTR_TYPE_STRING,
            description: `The NSG system id where VNF is deployed`,
            userlabel: `NSG System ID`,
        }),
        NSGatewayID: new NUAttribute({
            localName: 'NSGatewayID',
            attributeType: NUAttribute.ATTR_TYPE_STRING,
            description: `The NSG instance id where VNF is deployed`,
            isRequired: true,
            isCreateOnly: true,
            canOrder: true,
            canSearch: true,
            userlabel: `NS Gateway ID`,
        }),
        taskState: new NUAttribute({
            localName: 'taskState',
            attributeType: NUAttribute.ATTR_TYPE_ENUM,
            description: `Current state of operation/task`,
            canOrder: true,
            canSearch: true,
            choices: [NUVNFTaskStateEnum.DEPLOYING, NUVNFTaskStateEnum.NONE,
                NUVNFTaskStateEnum.STARTING, NUVNFTaskStateEnum.STOPPING,
                NUVNFTaskStateEnum.UNDEPLOYING],
            userlabel: `Task State`,
        }),
        lastKnownError: new NUAttribute({
            localName: 'lastKnownError',
            attributeType: NUAttribute.ATTR_TYPE_STRING,
            description: `Last error reported`,
            canSearch: true,
            userlabel: `Last Known Error`,
        }),
        memoryMB: new NUAttribute({
            localName: 'memoryMB',
            attributeType: NUAttribute.ATTR_TYPE_INTEGER,
            description: `Memory (in MB) to be allocated for this VNF instance.`,
            canOrder: true,
            canSearch: true,
            userlabel: `Memory (MB)`,
        }),
        vendor: new NUAttribute({
            localName: 'vendor',
            attributeType: NUAttribute.ATTR_TYPE_STRING,
            description: `The vendor for VNF`,
            canOrder: true,
            canSearch: true,
            userlabel: `Vendor`,
        }),
        metadataID: new NUAttribute({
            localName: 'metadataID',
            attributeType: NUAttribute.ATTR_TYPE_STRING,
            description: `Id of referenced metadata object`,
            canOrder: true,
            canSearch: true,
            userlabel: `Metadata`,
        }),
        allowedActions: new NUAttribute({
            localName: 'allowedActions',
            attributeType: NUAttribute.ATTR_TYPE_LIST,
            description: `Action allowed to  performed on VNF based on current status and taskState`,
            choices: [NUVNFAllowedActionsEnum.DEPLOY, NUVNFAllowedActionsEnum.REDEPLOY,
                NUVNFAllowedActionsEnum.RESTART, NUVNFAllowedActionsEnum.START,
                NUVNFAllowedActionsEnum.STOP, NUVNFAllowedActionsEnum.UNDEPLOY],
            subType: NUAttribute.ATTR_TYPE_ENUM,
            userlabel: `Allowed Actions`,
        }),
        enterpriseID: new NUAttribute({
            localName: 'enterpriseID',
            attributeType: NUAttribute.ATTR_TYPE_STRING,
            description: `ID of the enterprise that this VNF belongs to`,
            userlabel: `Enterprise ID`,
        }),
        isAttachedToDescriptor: new NUAttribute({
            localName: 'isAttachedToDescriptor',
            attributeType: NUAttribute.ATTR_TYPE_BOOLEAN,
            description: `This specifies if VNF instance is using VNF descriptor or it is decoupled from it`,
            canOrder: true,
            canSearch: true,
            userlabel: `Is Attached To Descriptor`,
        }),
        associatedVNFMetadataID: new NUAttribute({
            localName: 'associatedVNFMetadataID',
            attributeType: NUAttribute.ATTR_TYPE_STRING,
            description: `VNF metadata associated to VNF instance. `,
            userlabel: `Metadata`,
        }),
        associatedVNFThresholdPolicyID: new NUAttribute({
            localName: 'associatedVNFThresholdPolicyID',
            attributeType: NUAttribute.ATTR_TYPE_STRING,
            description: `VNF threshold policy associated to VNF instance`,
            userlabel: `Threshold Policy`,
        }),
        status: new NUAttribute({
            localName: 'status',
            attributeType: NUAttribute.ATTR_TYPE_ENUM,
            description: `State/Status of the VNF`,
            canOrder: true,
            canSearch: true,
            choices: [NUVNFStatusEnum.BLOCKED, NUVNFStatusEnum.CRASHED, NUVNFStatusEnum.DYING,
                NUVNFStatusEnum.IDLE, NUVNFStatusEnum.INIT, NUVNFStatusEnum.LAST,
                NUVNFStatusEnum.PAUSED, NUVNFStatusEnum.PMSUSPENDED, NUVNFStatusEnum.RUNNING,
                NUVNFStatusEnum.SHUTDOWN, NUVNFStatusEnum.SHUTOFF],
            userlabel: `Status`,
        }),
        storageGB: new NUAttribute({
            localName: 'storageGB',
            attributeType: NUAttribute.ATTR_TYPE_INTEGER,
            description: `Disk storage (in GB) to be allocated for deployed VNF instance`,
            canOrder: true,
            canSearch: true,
            userlabel: `Storage (GB)`,
        }),
        type: new NUAttribute({
            localName: 'type',
            attributeType: NUAttribute.ATTR_TYPE_ENUM,
            description: `Type of virtual network function`,
            isReadOnly: true,
            canOrder: true,
            canSearch: true,
            choices: [NUVNFTypeEnum.FIREWALL, NUVNFTypeEnum.WAN_OPT],
            userlabel: `Type`,
        }),
    }

    static getClassName() {
        return 'NUVNF';
    }
    
    static getAllowedJobCommands() {
        return [NUJobCommandEnum.DEPLOY, NUJobCommandEnum.REDEPLOY, NUJobCommandEnum.RESTART,
                NUJobCommandEnum.START, NUJobCommandEnum.STOP, NUJobCommandEnum.SYNC,
                NUJobCommandEnum.UNDEPLOY];
    }
    
    get RESTName() {
        return 'vnf';
    }
    
    get resourceName() {
        return 'vnfs';
    }
    
    getClassName() {
        return NUVNF.getClassName();
    }

    getAllowedJobCommands() {
        return NUVNF.getAllowedJobCommands();
    }
}

ServiceClassRegistry.register(NUVNF);
```