### PR TITLE
generate supportsAlarms

### DIFF
--- a/monolithe/generators/lang/javascript/templates/entity.js.tpl
+++ b/monolithe/generators/lang/javascript/templates/entity.js.tpl
@@ -66,6 +66,10 @@ export default class {{ class_prefix }}{{ specification.entity_name }} extends {
         return {{commands_str|wordwrap(80,false,'\n                ')}}
     }
     
+    static supportsAlarms() {
+        return {% if specification.supportsAlarms %}true{% else %}false{% endif %};
+    }
+    
     get RESTName() {
         return '{{ specification.rest_name }}';
     }

--- a/monolithe/generators/lang/javascript/writers/apiversionwriter.py
+++ b/monolithe/generators/lang/javascript/writers/apiversionwriter.py
@@ -153,6 +153,7 @@ class APIVersionWriter(TemplateFileWriter):
         if specification.allowed_job_commands and not (set(specification.allowed_job_commands).issubset(self.job_commands)):
             raise Exception("Invalid allowed_job_commands %s specified in entity %s" % (specification.allowed_job_commands, specification.entity_name))
             
+        specification.supportsAlarms = len(filter(lambda child_api : child_api.rest_name == "alarm", specification.child_apis)) == 1
         
         filename = "%s%s.js" % (self._class_prefix, specification.entity_name)
 


### PR DESCRIPTION
Sample generated code:
When alarm supported:
```
import NUAttribute from 'service/NUAttribute';
import ServiceClassRegistry from 'service/ServiceClassRegistry';
import NUAbstractNamedEntity from './abstract/NUAbstractNamedEntity';
import { NUWANServiceServiceTypeEnum, NUWANServiceConfigTypeEnum, NUWANServiceTunnelTypeEnum }
    from './enums';
import { NUPermittedActionEnum } from '@/enums';


/* Represents WANService entity
   Represents a WAN Service Object.
*/
export default class NUWANService extends NUAbstractNamedEntity {
    constructor(...args) {
        super(...args);
        this.defineProperties({
            WANServiceIdentifier: null,
            IRBEnabled: null,
            permittedAction: null,
            servicePolicy: null,
            serviceType: null,
            vnId: null,
            enterpriseName: null,
            domainName: null,
            configType: null,
            orphan: null,
            useUserMnemonic: null,
            userMnemonic: null,
            associatedDomainID: null,
            associatedVPNConnectID: null,
            tunnelType: null,
            externalRouteTarget: null,
        });
    }

    static entityDescriptor = {
        description: `Represents a WAN Service Object.`,
        userlabel: `WAN Service`,
    }

    static attributeDescriptors = {
        ...NUAbstractNamedEntity.attributeDescriptors,
        WANServiceIdentifier: new NUAttribute({
            localName: 'WANServiceIdentifier',
            attributeType: NUAttribute.ATTR_TYPE_STRING,
            description: `Identifier of the WAN Service`,
            canOrder: true,
            canSearch: true,
            userlabel: `WAN Service Identifier`,
        }),
        IRBEnabled: new NUAttribute({
            localName: 'IRBEnabled',
            attributeType: NUAttribute.ATTR_TYPE_BOOLEAN,
            description: `Determines whether Integrated Routing and Bridging is enabled on the WAN Service`,
            canOrder: true,
            canSearch: true,
            userlabel: `IRB Enabled`,
        }),
        permittedAction: new NUAttribute({
            localName: 'permittedAction',
            attributeType: NUAttribute.ATTR_TYPE_ENUM,
            description: `The permitted  action to USE/EXTEND  this Gateway.`,
            choices: [NUPermittedActionEnum.ALL, NUPermittedActionEnum.DEPLOY,
                NUPermittedActionEnum.EXTEND, NUPermittedActionEnum.INSTANTIATE,
                NUPermittedActionEnum.READ, NUPermittedActionEnum.USE],
            userlabel: `Permitted Action`,
        }),
        servicePolicy: new NUAttribute({
            localName: 'servicePolicy',
            attributeType: NUAttribute.ATTR_TYPE_STRING,
            description: `Name of 7X50 Policy associated with the service`,
            canOrder: true,
            canSearch: true,
            userlabel: `Service Policy`,
        }),
        serviceType: new NUAttribute({
            localName: 'serviceType',
            attributeType: NUAttribute.ATTR_TYPE_ENUM,
            description: `Type of the service.`,
            isRequired: true,
            canOrder: true,
            canSearch: true,
            choices: [NUWANServiceServiceTypeEnum.L2, NUWANServiceServiceTypeEnum.L3],
            userlabel: `Service Type`,
        }),
        vnId: new NUAttribute({
            localName: 'vnId',
            attributeType: NUAttribute.ATTR_TYPE_INTEGER,
            description: `VNID of the BackHaul Subnet of L3Domain /L2Domain to which this WANService is associated`,
            subType: NUAttribute.ATTR_TYPE_LONG,
            userlabel: `VNID`,
        }),
        enterpriseName: new NUAttribute({
            localName: 'enterpriseName',
            attributeType: NUAttribute.ATTR_TYPE_STRING,
            description: `The associated enterprise name.`,
            userlabel: `Enterprise Name`,
        }),
        domainName: new NUAttribute({
            localName: 'domainName',
            attributeType: NUAttribute.ATTR_TYPE_STRING,
            description: `The associated domain name.`,
            userlabel: `Domain Name`,
        }),
        configType: new NUAttribute({
            localName: 'configType',
            attributeType: NUAttribute.ATTR_TYPE_ENUM,
            description: `Type of the CONFIG.`,
            canOrder: true,
            canSearch: true,
            choices: [NUWANServiceConfigTypeEnum.DYNAMIC, NUWANServiceConfigTypeEnum.STATIC],
            userlabel: `Config Type`,
        }),
        orphan: new NUAttribute({
            localName: 'orphan',
            attributeType: NUAttribute.ATTR_TYPE_BOOLEAN,
            description: `Indicates if this WAN Service is orphan or not.`,
            userlabel: `Orphan`,
        }),
        useUserMnemonic: new NUAttribute({
            localName: 'useUserMnemonic',
            attributeType: NUAttribute.ATTR_TYPE_BOOLEAN,
            description: `Determines whether to use user mnemonic of the WAN Service`,
            canOrder: true,
            canSearch: true,
            userlabel: `Use User Mnemonic`,
        }),
        userMnemonic: new NUAttribute({
            localName: 'userMnemonic',
            attributeType: NUAttribute.ATTR_TYPE_STRING,
            description: `user mnemonic of the WAN Service`,
            canOrder: true,
            canSearch: true,
            userlabel: `User Mnemonic`,
        }),
        associatedDomainID: new NUAttribute({
            localName: 'associatedDomainID',
            attributeType: NUAttribute.ATTR_TYPE_STRING,
            description: `ID of the entity to which the WAN Service is attached to. This could be ID DOMAIN/L2DOMAIN`,
            userlabel: `Associated Domain ID`,
        }),
        associatedVPNConnectID: new NUAttribute({
            localName: 'associatedVPNConnectID',
            attributeType: NUAttribute.ATTR_TYPE_STRING,
            description: `The associated vpn connect ID.`,
            userlabel: `Associated VPN Connect ID`,
        }),
        tunnelType: new NUAttribute({
            localName: 'tunnelType',
            attributeType: NUAttribute.ATTR_TYPE_ENUM,
            description: `Type of the tunnel.`,
            choices: [NUWANServiceTunnelTypeEnum.DC_DEFAULT, NUWANServiceTunnelTypeEnum.GRE,
                NUWANServiceTunnelTypeEnum.VXLAN],
            userlabel: `Tunnel Type`,
        }),
        externalRouteTarget: new NUAttribute({
            localName: 'externalRouteTarget',
            attributeType: NUAttribute.ATTR_TYPE_STRING,
            description: `Route target associated with the WAN. It is an optional parameterthat can be provided by the user`,
            canOrder: true,
            canSearch: true,
            userlabel: `External Route Target`,
        }),
    }

    static getClassName() {
        return 'NUWANService';
    }
    
    static getAllowedJobCommands() {
        return [];
    }
    
    static supportsAlarms() {
        return true;
    }
    
    get RESTName() {
        return 'service';
    }
    
    get resourceName() {
        return 'services';
    }
    
    getClassName() {
        return NUWANService.getClassName();
    }

    getAllowedJobCommands() {
        return NUWANService.getAllowedJobCommands();
    }
}

ServiceClassRegistry.register(NUWANService);
```
When alarm not supported:
```
import NUAttribute from 'service/NUAttribute';
import ServiceClassRegistry from 'service/ServiceClassRegistry';
import NUAbstractNamedEntity from './abstract/NUAbstractNamedEntity';


/* Represents NSGGroup entity
*/
export default class NUNSGGroup extends NUAbstractNamedEntity {
    constructor(...args) {
        super(...args);
        this.defineProperties({
        });
    }

    static entityDescriptor = {
        description: `None`,
        userlabel: `NSG Group`,
    }

    static attributeDescriptors = {
        ...NUAbstractNamedEntity.attributeDescriptors,
    }

    static getClassName() {
        return 'NUNSGGroup';
    }
    
    static getAllowedJobCommands() {
        return [];
    }
    
    static supportsAlarms() {
        return false;
    }
    
    get RESTName() {
        return 'nsggroup';
    }
    
    get resourceName() {
        return 'nsggroups';
    }
    
    getClassName() {
        return NUNSGGroup.getClassName();
    }

    getAllowedJobCommands() {
        return NUNSGGroup.getAllowedJobCommands();
    }
}

ServiceClassRegistry.register(NUNSGGroup);
```