### PR TITLE
undefined as default if default value not specified and for read-only attrs

### DIFF
--- a/monolithe/generators/lang/javascript/templates/entity.js.tpl
+++ b/monolithe/generators/lang/javascript/templates/entity.js.tpl
@@ -25,7 +25,7 @@ export default class {{ class_prefix }}{{ specification.entity_name }} extends {
             isTemplate: true,{% endif -%}    
         {%- for attribute in specification.attributes_modified %}
             {% set is_enum = attribute.allowed_choices and attribute.allowed_choices|length > 0  -%}
-            {{ attribute.name }}: {% if attribute.default_value %}{% if attribute.local_type == "string" %}'{{ attribute.default_value }}'{% else %}{% if is_enum  %}{{ class_prefix }}{% set attr_name %}{% if attribute.name not in  generic_enum_attributes%}{{ attribute.name }}{% else %}{{ generic_enum_attributes[attribute.name].name }}{% endif %}{% endset %}{% if attribute.name not in  generic_enum_attributes%}{{ specification.entity_name }}{% endif %}{{ attr_name[0].upper() + attr_name[1:] }}Enum.{% endif %}{{ attribute.default_value }}{% if is_enum  %}.name{% endif %}{% endif %}{% else %}null{% endif %},
+            {{ attribute.name }}: {% if attribute.default_value and not attribute.read_only %}{% if attribute.local_type == "string" %}'{{ attribute.default_value }}'{% else %}{% if is_enum  %}{{ class_prefix }}{% set attr_name %}{% if attribute.name not in  generic_enum_attributes%}{{ attribute.name }}{% else %}{{ generic_enum_attributes[attribute.name].name }}{% endif %}{% endset %}{% if attribute.name not in  generic_enum_attributes%}{{ specification.entity_name }}{% endif %}{{ attr_name[0].upper() + attr_name[1:] }}Enum.{% endif %}{{ attribute.default_value }}{% if is_enum  %}.name{% endif %}{% endif %}{% else %}undefined{% endif %},
         {%- endfor %}
         });
     }


### PR DESCRIPTION
sample generated code:
```
import NUAttribute from 'service/NUAttribute';
import ServiceClassRegistry from 'service/ServiceClassRegistry';
import NUEntity from 'service/NUEntity';
import { NUCommandCommandEnum, NUCommandStatusEnum, NUCommandOverrideEnum } from './enums';


/* Represents Command entity
   A Command represents an operation that needs to be executed on an entity (NSG, Gateway, ...)
   which requires little processing by VSD, but may result in a long activity on the external
   entity.  An example would be to trigger an action on VSD so that a Gateway download a new image.
   VSDs handling of the request is limited to generating a message to be sent to the device on which
   the download process is expected.  The device then acts on the request and proceeds with the
   download...  That may be a long process.  The commands API is similar to the Jobs API with
   regards to triggering operations on objects.
*/
export default class NUCommand extends NUEntity {
    constructor(...args) {
        super(...args);
        this.defineProperties({
            detail: undefined,
            detailedStatus: undefined,
            detailedStatusCode: undefined,
            command: NUCommandCommandEnum.UNKNOWN.name,
            commandInformation: undefined,
            associatedParam: undefined,
            associatedParamType: undefined,
            status: undefined,
            fullCommand: undefined,
            summary: undefined,
            override: NUCommandOverrideEnum.UNSPECIFIED.name,
        });
    }

    static entityDescriptor = {
        description: `A Command represents an operation that needs to be executed on an entity (NSG, Gateway, ...) which requires little processing by VSD, but may result in a long activity on the external entity.  An example would be to trigger an action on VSD so that a Gateway download a new image.  VSDs handling of the request is limited to generating a message to be sent to the device on which the download process is expected.  The device then acts on the request and proceeds with the download...  That may be a long process.  The commands API is similar to the Jobs API with regards to triggering operations on objects.`,
        userlabel: `Command`,
    }

    static attributeDescriptors = {
        ...NUEntity.attributeDescriptors,
        detail: new NUAttribute({
            localName: 'detail',
            attributeType: NUAttribute.ATTR_TYPE_STRING,
            description: `Details about the command execution as reported directly from the NSG independent of status codes.`,
            isReadOnly: true,
            userlabel: `Detail`,
        }),
        detailedStatus: new NUAttribute({
            localName: 'detailedStatus',
            attributeType: NUAttribute.ATTR_TYPE_STRING,
            description: `A string representing the detailed status of the operation that was triggered by the execution of the Command instance.`,
            isReadOnly: true,
            isTransient: true,
            userlabel: `Detailed Status`,
        }),
        detailedStatusCode: new NUAttribute({
            localName: 'detailedStatusCode',
            attributeType: NUAttribute.ATTR_TYPE_INTEGER,
            description: `A numerical code mapping to a list of detailed statuses that can apply to a Command instance.`,
            isReadOnly: true,
            canOrder: true,
            canSearch: true,
            userlabel: `Detailed Status Code`,
        }),
        command: new NUAttribute({
            localName: 'command',
            attributeType: NUAttribute.ATTR_TYPE_ENUM,
            description: `Specifies the type of command that is stated for execution on the system receiving the operation request.  A request for download, a request for upgrade, a request for revocation, ...`,
            isRequired: true,
            isCreateOnly: true,
            canOrder: true,
            canSearch: true,
            choices: [NUCommandCommandEnum.NSG_APPLY_PATCH,
                NUCommandCommandEnum.NSG_DOWNLOAD_OS_IMAGE,
                NUCommandCommandEnum.NSG_UPGRADE_TO_IMAGE, NUCommandCommandEnum.UNKNOWN],
            userlabel: `Command Requested`,
        }),
        commandInformation: new NUAttribute({
            localName: 'commandInformation',
            attributeType: NUAttribute.ATTR_TYPE_STRING,
            description: `Informative details on what command is to be executed.  It complements the commandType attribute.  An example of a value could be a URL, a version number, a UUID of another object, ...`,
            isReadOnly: true,
            userlabel: `Command Information`,
        }),
        associatedParam: new NUAttribute({
            localName: 'associatedParam',
            attributeType: NUAttribute.ATTR_TYPE_STRING,
            description: `Parameters to be supplied for execution of this command. This could either be a string of parameters or ID of an object supplying parameters.`,
            userlabel: `Associated Parameter`,
        }),
        associatedParamType: new NUAttribute({
            localName: 'associatedParamType',
            attributeType: NUAttribute.ATTR_TYPE_STRING,
            description: `Type of the object which supplies parameters for this command.`,
            canOrder: true,
            canSearch: true,
            userlabel: `Associated Parameter Type`,
        }),
        status: new NUAttribute({
            localName: 'status',
            attributeType: NUAttribute.ATTR_TYPE_ENUM,
            description: `The status of the Command from a VSD perspective.`,
            isReadOnly: true,
            canOrder: true,
            canSearch: true,
            choices: [NUCommandStatusEnum.COMPLETE, NUCommandStatusEnum.FAILED,
                NUCommandStatusEnum.STARTED, NUCommandStatusEnum.UNKNOWN],
            userlabel: `Status`,
        }),
        fullCommand: new NUAttribute({
            localName: 'fullCommand',
            attributeType: NUAttribute.ATTR_TYPE_STRING,
            description: `Full command including parameters that is to be executed.`,
            isReadOnly: true,
            userlabel: `Full Command`,
        }),
        summary: new NUAttribute({
            localName: 'summary',
            attributeType: NUAttribute.ATTR_TYPE_STRING,
            description: `A generated summary for the action giving some general context on the command executed.`,
            isRequired: true,
            isReadOnly: true,
            userlabel: `Summary`,
        }),
        override: new NUAttribute({
            localName: 'override',
            attributeType: NUAttribute.ATTR_TYPE_ENUM,
            description: `Operator specified action which overrides the normal life cycle of a command.`,
            canOrder: true,
            canSearch: true,
            choices: [NUCommandOverrideEnum.ABANDON, NUCommandOverrideEnum.UNSPECIFIED],
            userlabel: `Override`,
        }),
    }

    static getClassName() {
        return 'NUCommand';
    }
    
    static getAllowedJobCommands() {
        return [];
    }
    
    static supportsAlarms() {
        return false;
    }
    
    static getInstanceFromID(ID) {
        const instance = new NUCommand();
        instance.ID = ID;
        return instance;
    }
    
    get RESTName() {
        return 'command';
    }
    
    get resourceName() {
        return 'commands';
    }
    
    getClassName() {
        return NUCommand.getClassName();
    }

    getAllowedJobCommands() {
        return NUCommand.getAllowedJobCommands();
    }
}

ServiceClassRegistry.register(NUCommand);
```