### PR TITLE
change for supportsPermissions

### DIFF
--- a/monolithe/generators/lang/javascript/templates/entity.js.tpl
+++ b/monolithe/generators/lang/javascript/templates/entity.js.tpl
@@ -70,6 +70,13 @@ export default class {{ class_prefix }}{{ specification.entity_name }} extends {
         return {% if specification.supportsAlarms %}true{% else %}false{% endif %};
     }
     
+    {% if specification.supportsPermissions -%}
+    static supportsPermissions() {
+        return true;
+    }
+    
+    {% endif -%}
+    
     static getInstanceFromID(ID) {
         const instance = new {{ class_prefix }}{{ specification.entity_name }}();
         instance.ID = ID;

--- a/monolithe/generators/lang/javascript/writers/apiversionwriter.py
+++ b/monolithe/generators/lang/javascript/writers/apiversionwriter.py
@@ -155,6 +155,8 @@ class APIVersionWriter(TemplateFileWriter):
             
         specification.supportsAlarms = len(filter(lambda child_api : child_api.rest_name == "alarm", specification.child_apis)) == 1
         
+        specification.supportsPermissions = len(filter(lambda child_api : child_api.rest_name == "enterprisepermission" or child_api.rest_name == "permission", specification.child_apis)) > 0
+
         filename = "%s%s.js" % (self._class_prefix, specification.entity_name)
 
         self.model_list.append("%s%s" %(self._class_prefix, specification.entity_name))


### PR DESCRIPTION
static method generated only if entity supports permissions,

Sample generated code:
```
import NUAttribute from 'service/NUAttribute';
import ServiceClassRegistry from 'service/ServiceClassRegistry';
import NUAbstractNamedEntity from './abstract/NUAbstractNamedEntity';
import { NUL2DomainTemplateEntityStateEnum, NUL2DomainTemplatePolicyChangeStatusEnum } from
    './enums';
import { NUEnabledEnum, NUIPTypeEnum } from '@/enums';
import { NUJobCommandEnum } from './enums';


/* Represents L2DomainTemplate entity
   An L2 Domain is a distributed logical switch that enables L2 communication. An L2 Domain template
   is a model that can be instantiated as often as required, thereby creating real, functioning L2
   Domains.
*/
export default class NUL2DomainTemplate extends NUAbstractNamedEntity {
    constructor(...args) {
        super(...args);
        this.defineProperties({
            isTemplate: true,
            DHCPManaged: undefined,
            DPI: NUEnabledEnum.DISABLED.name,
            IPType: undefined,
            IPv6Address: undefined,
            IPv6Gateway: undefined,
            gateway: undefined,
            address: undefined,
            netmask: undefined,
            encryption: undefined,
            entityState: undefined,
            policyChangeStatus: undefined,
            useGlobalMAC: NUEnabledEnum.DISABLED.name,
            associatedMulticastChannelMapID: undefined,
            multicast: undefined,
            dynamicIpv6Address: false,
        });
    }

    static entityDescriptor = {
        description: `An L2 Domain is a distributed logical switch that enables L2 communication. An L2 Domain template is a model that can be instantiated as often as required, thereby creating real, functioning L2 Domains.`,
        userlabel: `L2 Domain Template`,
    }

    static attributeDescriptors = {
        ...NUAbstractNamedEntity.attributeDescriptors,
        DHCPManaged: new NUAttribute({
            localName: 'DHCPManaged',
            attributeType: NUAttribute.ATTR_TYPE_BOOLEAN,
            description: `decides whether L2Domain / L2Domain template DHCP is managed by VSD`,
            canOrder: true,
            canSearch: true,
            userlabel: `Manage addressing with internal VSD DHCP`,
        }),
        DPI: new NUAttribute({
            localName: 'DPI',
            attributeType: NUAttribute.ATTR_TYPE_ENUM,
            description: `determines whether or not Deep packet inspection is enabled`,
            canOrder: true,
            canSearch: true,
            choices: [NUEnabledEnum.DISABLED, NUEnabledEnum.ENABLED, NUEnabledEnum.INHERITED],
            userlabel: `DPI`,
        }),
        IPType: new NUAttribute({
            localName: 'IPType',
            attributeType: NUAttribute.ATTR_TYPE_ENUM,
            description: `IPv4 or DUALSTACK`,
            canOrder: true,
            canSearch: true,
            choices: [NUIPTypeEnum.DUALSTACK, NUIPTypeEnum.IPV4],
            userlabel: `IP Type`,
        }),
        IPv6Address: new NUAttribute({
            localName: 'IPv6Address',
            attributeType: NUAttribute.ATTR_TYPE_STRING,
            description: `IPV6 address of the route - Optional`,
            canOrder: true,
            canSearch: true,
            userlabel: `IPv6 Address`,
        }),
        IPv6Gateway: new NUAttribute({
            localName: 'IPv6Gateway',
            attributeType: NUAttribute.ATTR_TYPE_STRING,
            description: `The IPv6 address of the gateway of this subnet`,
            canOrder: true,
            canSearch: true,
            userlabel: `IPv6 Gateway`,
        }),
        gateway: new NUAttribute({
            localName: 'gateway',
            attributeType: NUAttribute.ATTR_TYPE_STRING,
            description: `The IP address of the gateway of this l2 domain`,
            canOrder: true,
            canSearch: true,
            userlabel: `Gateway`,
        }),
        address: new NUAttribute({
            localName: 'address',
            attributeType: NUAttribute.ATTR_TYPE_STRING,
            description: `Network address of the L2Domain / L2Domain template defined. `,
            canOrder: true,
            canSearch: true,
            userlabel: `Network`,
        }),
        netmask: new NUAttribute({
            localName: 'netmask',
            attributeType: NUAttribute.ATTR_TYPE_STRING,
            description: `Netmask of the L2Domain / L2Domain template defined`,
            canOrder: true,
            canSearch: true,
            userlabel: `Netmask`,
        }),
        encryption: new NUAttribute({
            localName: 'encryption',
            attributeType: NUAttribute.ATTR_TYPE_ENUM,
            description: `Determines whether IPSEC is enabled Possible values are ENABLED, DISABLED, .`,
            canSearch: true,
            choices: [NUEnabledEnum.DISABLED, NUEnabledEnum.ENABLED],
            userlabel: `Encryption`,
        }),
        entityState: new NUAttribute({
            localName: 'entityState',
            attributeType: NUAttribute.ATTR_TYPE_ENUM,
            description: `Intermediate State of L2 Domain.`,
            canOrder: true,
            canSearch: true,
            choices: [NUL2DomainTemplateEntityStateEnum.MARKED_FOR_DELETION,
                NUL2DomainTemplateEntityStateEnum.UNDER_CONSTRUCTION],
            userlabel: `Entity State`,
        }),
        policyChangeStatus: new NUAttribute({
            localName: 'policyChangeStatus',
            attributeType: NUAttribute.ATTR_TYPE_ENUM,
            canSearch: true,
            choices: [NUL2DomainTemplatePolicyChangeStatusEnum.APPLIED,
                NUL2DomainTemplatePolicyChangeStatusEnum.DISCARDED,
                NUL2DomainTemplatePolicyChangeStatusEnum.STARTED],
            userlabel: `Policy Change Status`,
        }),
        useGlobalMAC: new NUAttribute({
            localName: 'useGlobalMAC',
            attributeType: NUAttribute.ATTR_TYPE_ENUM,
            description: `Enable this flag to use system configured globalMACAddress as the gateway mac address for managed l2 domains`,
            canSearch: true,
            choices: [NUEnabledEnum.DISABLED, NUEnabledEnum.ENABLED],
            userlabel: `Global Subnet GW MAC`,
        }),
        associatedMulticastChannelMapID: new NUAttribute({
            localName: 'associatedMulticastChannelMapID',
            attributeType: NUAttribute.ATTR_TYPE_STRING,
            description: `The ID of the Multi Cast Channel Map this L2Domain / L2Domain template template is associated with. This has to be set when  enableMultiCast is set to ENABLED`,
            userlabel: `Associated Multicast Channel Map ID`,
        }),
        multicast: new NUAttribute({
            localName: 'multicast',
            attributeType: NUAttribute.ATTR_TYPE_ENUM,
            description: `Indicates multicast policy on L2Domain template.`,
            canSearch: true,
            choices: [NUEnabledEnum.DISABLED, NUEnabledEnum.ENABLED, NUEnabledEnum.INHERITED],
            userlabel: `Multicast`,
        }),
        dynamicIpv6Address: new NUAttribute({
            localName: 'dynamicIpv6Address',
            attributeType: NUAttribute.ATTR_TYPE_BOOLEAN,
            description: `Turn on or off dynamic allocation of IPV6 address`,
            userlabel: `Auto IPv6 assignment`,
        }),
    }

    static getClassName() {
        return 'NUL2DomainTemplate';
    }
    
    static getAllowedJobCommands() {
        return [NUJobCommandEnum.EXPORT, NUJobCommandEnum.IMPORT];
    }
    
    static supportsAlarms() {
        return false;
    }
    
    static supportsPermissions() {
        return true;
    }
    
    static getInstanceFromID(ID) {
        const instance = new NUL2DomainTemplate();
        instance.ID = ID;
        return instance;
    }
    
    get RESTName() {
        return 'l2domaintemplate';
    }
    
    get resourceName() {
        return 'l2domaintemplates';
    }
    
    getClassName() {
        return NUL2DomainTemplate.getClassName();
    }

    getAllowedJobCommands() {
        return NUL2DomainTemplate.getAllowedJobCommands();
    }
}

ServiceClassRegistry.register(NUL2DomainTemplate);
```