### PR TITLE
vspk-javascript: override for vnf.lastUserAction

### DIFF
--- a/monolithe/generators/lang/javascript/config/config.json
+++ b/monolithe/generators/lang/javascript/config/config.json
@@ -14,6 +14,6 @@
         "nsgateway": ["TPMStatus"],
         "ingressadvfwdentrytemplate": ["appType"],
         "link": ["acceptanceCriteria"],
-        "vnf": ["allowedActions"]
+        "vnf": ["allowedActions", "lastUserAction"]
     }
 }


### PR DESCRIPTION
This was a new attribute added to api-spec.
Code snippet from generated NUVNF.js:
Before:
```
        lastUserAction: new NUAttribute({
            localName: 'lastUserAction',
            attributeType: NUAttribute.ATTR_TYPE_ENUM,
            description: `Last action perform by user`,
            isReadOnly: true,
            canSearch: true,
            choices: [NUPermittedActionEnum.DEPLOY, NUPermittedActionEnum.REDEPLOY,
                NUPermittedActionEnum.RESTART, NUPermittedActionEnum.START,
                NUPermittedActionEnum.STOP, NUPermittedActionEnum.UNDEPLOY],
            userlabel: `Last User Action`,
        }),
```
After:
```
        lastUserAction: new NUAttribute({
            localName: 'lastUserAction',
            attributeType: NUAttribute.ATTR_TYPE_ENUM,
            description: `Last action perform by user`,
            isReadOnly: true,
            canSearch: true,
            choices: [NUVNFLastUserActionEnum.DEPLOY, NUVNFLastUserActionEnum.REDEPLOY,
                NUVNFLastUserActionEnum.RESTART, NUVNFLastUserActionEnum.START,
                NUVNFLastUserActionEnum.STOP, NUVNFLastUserActionEnum.UNDEPLOY],
            userlabel: `Last User Action`,
        }),
```
