### PR TITLE
vspk-javascript: generate index.js for locales, avoid NUAttribute import if not needed

### DIFF
--- a/monolithe/generators/lang/javascript/templates/entity.js.tpl
+++ b/monolithe/generators/lang/javascript/templates/entity.js.tpl
@@ -1,4 +1,5 @@
-{%- if specification.attributes_modified %}import {{ class_prefix }}Attribute from 'service/{{ class_prefix }}Attribute';{% endif %}
+{% set new_line = "\n"  -%}
+{% if specification.attributes_modified -%}import {{ class_prefix }}Attribute from 'service/{{ class_prefix }}Attribute';{{ new_line }}{%- endif -%}
 import ServiceClassRegistry from 'service/ServiceClassRegistry';
 import {{ class_prefix }}{{ superclass_name}} from '{% if superclass_name == "AbstractNamedEntity" %}./abstract/{% else %}service/{% endif %}{{ class_prefix }}{{ superclass_name }}';
 {%- if enum_attrs_to_import and enum_attrs_to_import|length > 0  %}

--- a/monolithe/generators/lang/javascript/templates/entity.js.tpl
+++ b/monolithe/generators/lang/javascript/templates/entity.js.tpl
@@ -1,4 +1,4 @@
-import {{ class_prefix }}Attribute from 'service/{{ class_prefix }}Attribute';
+{%- if specification.attributes_modified %}import {{ class_prefix }}Attribute from 'service/{{ class_prefix }}Attribute';{% endif %}
 import ServiceClassRegistry from 'service/ServiceClassRegistry';
 import {{ class_prefix }}{{ superclass_name}} from '{% if superclass_name == "AbstractNamedEntity" %}./abstract/{% else %}service/{% endif %}{{ class_prefix }}{{ superclass_name }}';
 {%- if enum_attrs_to_import and enum_attrs_to_import|length > 0  %}

--- a/monolithe/generators/lang/javascript/templates/locales_index.js.tpl
+++ b/monolithe/generators/lang/javascript/templates/locales_index.js.tpl
@@ -1,0 +1,4 @@
+{%- for locale in locales_list %}
+{%- set export_str %}export { default as {{ locale }} } from './{{ locale }}.json';{%- endset %}
+{{ export_str|wordwrap(96,false,'\n    ')}}
+{%- endfor %}

--- a/monolithe/generators/lang/javascript/writers/apiversionwriter.py
+++ b/monolithe/generators/lang/javascript/writers/apiversionwriter.py
@@ -100,26 +100,21 @@ class APIVersionWriter(TemplateFileWriter):
 
     def _write_locales(self, specifications):
         if self.locale_on:
+            self.locales_list = []
             for rest_name, specification in specifications.items():
-                #enum_attrs_for_locale_template = {}
-                #enum_attrs = self.enum_attrs_for_locale[specification.entity_name]
-                #
-                #generic_enum_attrs = self.generic_enum_attrs_for_locale[specification.entity_name];
-                #if (generic_enum_attrs):
-                #    enum_attrs.extend(generic_enum_attrs)
-                #    
-                #if (enum_attrs):
-                #    for attribute in enum_attrs:
-                #        enum_name = "%s%s%sEnum" % (self._class_prefix, specification.entity_name, attribute.name[0].upper() + attribute.name[1:])
-                #        enum_attrs_for_locale_template[enum_name] = attribute.allowed_choices
-                
                 self._format_description_text(specification)            
                 filename = "%s.json" % (rest_name)
+                self.locales_list.append(rest_name)
                 self.write(destination = self.locale_directory,
                     filename=filename,
                     template_name="locale_entity.json.tpl",
                     specification = specification,
                     enum_attrs = {})
+                    
+            self.write(destination = self.locale_directory,
+                filename="index.js",
+                template_name="locales_index.js.tpl",
+                locales_list = sorted(self.locales_list))
             
     def _format_description_text(self, specification):
         if specification.description:


### PR DESCRIPTION
- Compared generated index.js against the file generated by create-index. Content is the same.
- new index.js file would get generated in `codegen/javascript/5.0/locales/en` same directory where the .json files get generated