### PR TITLE
handle type list with subtype as any other spec

### DIFF
--- a/monolithe/generators/lang/javascript/config/config.json
+++ b/monolithe/generators/lang/javascript/config/config.json
@@ -15,5 +15,6 @@
         "ingressadvfwdentrytemplate": ["appType", "addressOverrideType"],
         "link": ["acceptanceCriteria"],
         "vnf": ["allowedActions", "lastUserAction"]
-    }
+    },
+    "list_subtypes_generic": ["double", "enum", "long", "string"]
 }

--- a/monolithe/generators/lang/javascript/templates/entity.js.tpl
+++ b/monolithe/generators/lang/javascript/templates/entity.js.tpl
@@ -13,8 +13,8 @@ import {{ class_prefix }}{{ superclass_name}} from '{% if superclass_name == "Ab
 {%- if specification.allowed_job_commands %}
 import { {{ class_prefix }}JobCommandEnum } from './enums';
 {%- endif %}
-{%- for object_subtype in object_subtypes %}
-import {{ class_prefix }}{{ object_subtype }} from './{{ class_prefix }}{{ object_subtype }}';
+{%- for subtype in subtypes_for_import %}
+import {{ class_prefix }}{{ subtype }} from './{{ class_prefix }}{{ subtype }}';
 {%- endfor %}
 
 
@@ -45,6 +45,7 @@ export default class {{ class_prefix }}{{ specification.entity_name }} extends {
         {%- if specification.rest_name -%}{{ new_line }}        ...{{ class_prefix }}{{ superclass_name}}.attributeDescriptors,{% endif -%}
         {%- for attribute in specification.attributes_modified %}
         {% set type_object_with_subtype = attribute.local_type == "object" and attribute.subtype  -%}
+        {% set type_list_with_subtype = attribute.local_type == "list" and attribute.subtype and attribute.subtype in subtypes_for_import -%}
         {{ attribute.name }}: new {{ class_prefix }}Attribute({
             localName: '{{ attribute.name }}',
             attributeType: {{ class_prefix }}Attribute.ATTR_TYPE_{% if attribute.local_type == "integer" %}INTEGER{% elif type_object_with_subtype %}OBJECT{% elif attribute.local_type == "float" %}FLOAT{% elif attribute.local_type == "list" %}LIST{% elif attribute.local_type == "boolean" %}BOOLEAN{% elif attribute.local_type == "enum" and attribute.allowed_choices and attribute.allowed_choices|length > 0 %}ENUM{% else %}STRING{% endif %}{% if attribute.description %},
@@ -57,7 +58,7 @@ export default class {{ class_prefix }}{{ specification.entity_name }} extends {
             canSearch: true{% endif %}{% if attribute.allowed_choices and attribute.allowed_choices|length > 0  %},
             {%- set choices_str %}[{% for choice in attribute.allowed_choices %}{% if loop.index0 > 0 %}, {% endif %}{{ class_prefix }}{% set attr_name %}{% if attribute.name not in  generic_enum_attributes%}{{ attribute.name }}{% else %}{{ generic_enum_attributes[attribute.name].name }}{% endif %}{% endset %}{% if attribute.name not in  generic_enum_attributes%}{{ specification.entity_name }}{% endif %}{{ attr_name[0].upper() + attr_name[1:] }}Enum.{{choice}}{% endfor %}]{%- endset %}
             choices: {{choices_str|wordwrap(80,false,'\n                ')}}{% endif %},{% if attribute.subtype != None %}
-            subType: {{ class_prefix }}{% if type_object_with_subtype %}{{ attribute.subtype }},{% else %}Attribute.ATTR_TYPE_{% if attribute.subtype == "integer" %}INTEGER{% elif attribute.subtype == "long" %}LONG{% elif attribute.subtype == "float" %}FLOAT{% elif attribute.subtype == "boolean" %}BOOLEAN{% elif attribute.subtype == "enum" and attribute.allowed_choices and attribute.allowed_choices|length > 0 %}ENUM{% else %}STRING{% endif %},{% endif %}{% endif %}
+            subType: {{ class_prefix }}{% if type_object_with_subtype or type_list_with_subtype %}{{ attribute.subtype }},{% else %}Attribute.ATTR_TYPE_{% if attribute.subtype == "integer" %}INTEGER{% elif attribute.subtype == "long" %}LONG{% elif attribute.subtype == "float" %}FLOAT{% elif attribute.subtype == "boolean" %}BOOLEAN{% elif attribute.subtype == "enum" and attribute.allowed_choices and attribute.allowed_choices|length > 0 %}ENUM{% else %}STRING{% endif %},{% endif %}{% endif %}
             userlabel: `{{ attribute.userlabel }}`,
         }),
         {%- endfor %}

--- a/monolithe/generators/lang/javascript/writers/apiversionwriter.py
+++ b/monolithe/generators/lang/javascript/writers/apiversionwriter.py
@@ -194,14 +194,14 @@ class APIVersionWriter(TemplateFileWriter):
 
         self.generic_enum_attrs_for_locale[specification.entity_name] = generic_enum_attrs_in_entity.values()
         
-        object_subtypes = [attribute.subtype for attribute in specification.attributes if (attribute.local_type == "object"  and attribute.subtype)]
+        object_subtypes = set([attribute.subtype for attribute in specification.attributes if (attribute.local_type == "object"  and attribute.subtype)])
 
         invalid_object_attributes=[attribute.name for attribute in specification.attributes_modified if (attribute.local_type == "object" and not attribute.subtype in self.entity_names)]
 
         if invalid_object_attributes:
             Printer.log("Spec: %s: Attributes %s use invalid subtypes %s" % (filename, invalid_object_attributes, object_subtypes))
 
-        list_subtypes = [attribute.subtype for attribute in specification.attributes if (attribute.local_type == "list" and attribute.subtype not in self.list_subtypes_generic)]
+        list_subtypes = set([attribute.subtype for attribute in specification.attributes if (attribute.local_type == "list" and attribute.subtype not in self.list_subtypes_generic)])
 
         invalid_list_attributes=[attribute.name for attribute in specification.attributes_modified if (attribute.local_type == "list" and not attribute.subtype in self.entity_names and not attribute.subtype in self.list_subtypes_generic)]
 
@@ -222,7 +222,7 @@ class APIVersionWriter(TemplateFileWriter):
                     enum_attrs_to_import = enum_attrs_to_import,
                     generic_enum_attributes = generic_enum_attrs_in_entity,
                     generic_enum_attributes_to_import = set(generic_enum_attributes_to_import),
-                    subtypes_for_import = set(object_subtypes + list_subtypes))
+                    subtypes_for_import = object_subtypes.union(list_subtypes))
 
     def _isNamedEntity(self, attributes):
         attr_names = [attr.name for attr in attributes]

--- a/monolithe/generators/lang/javascript/writers/apiversionwriter.py
+++ b/monolithe/generators/lang/javascript/writers/apiversionwriter.py
@@ -201,7 +201,7 @@ class APIVersionWriter(TemplateFileWriter):
         if invalid_object_attributes:
             Printer.log("Spec: %s: Attributes %s use invalid subtypes %s" % (filename, invalid_object_attributes, object_subtypes))
 
-        list_subtypes = [attribute.subtype for attribute in specification.attributes if (attribute.local_type == "list"  and attribute.subtype not in self.list_subtypes_generic)]
+        list_subtypes = [attribute.subtype for attribute in specification.attributes if (attribute.local_type == "list" and attribute.subtype not in self.list_subtypes_generic)]
 
         invalid_list_attributes=[attribute.name for attribute in specification.attributes_modified if (attribute.local_type == "list" and not attribute.subtype in self.entity_names and not attribute.subtype in self.list_subtypes_generic)]
 


### PR DESCRIPTION
For now some of the specs use 'entity' and 'object' as subtype for list data type. I have just logged such attributes.

Sample (see attribute vscs in generated code below):
````
import NUAttribute from 'service/NUAttribute';
import ServiceClassRegistry from 'service/ServiceClassRegistry';
import NUEntity from 'service/NUEntity';
import NUVRS from './NUVRS';
import NUVSC from './NUVSC';


/* Represents NSGatewayMonitor entity
   This API can be used to gather read-only information about an NSG, including information on its
   state, system metrics, alarm counts, location and version. It is a single view of the full data
   available for an NSG.
*/
export default class NUNSGatewayMonitor extends NUEntity {
    constructor(...args) {
        super(...args);
        this.defineProperties({
            vrsinfo: undefined,
            vscs: undefined,
            nsginfo: undefined,
            nsgstate: undefined,
            nsgsummary: undefined,
        });
    }

    static entityDescriptor = {
        description: `This API can be used to gather read-only information about an NSG, including information on its state, system metrics, alarm counts, location and version. It is a single view of the full data available for an NSG.`,
        userlabel: `NSG monitor`,
    }

    static attributeDescriptors = {
        ...NUEntity.attributeDescriptors,
        vrsinfo: new NUAttribute({
            localName: 'vrsinfo',
            attributeType: NUAttribute.ATTR_TYPE_OBJECT,
            description: `information about VRS reported from sysmon in JSON format. Has info about cpu usage, memory usage, physical interfaces etc.`,
            isUnique: true,
            isReadOnly: true,
            subType: NUVRS,
            userlabel: `VRS information`,
        }),
        vscs: new NUAttribute({
            localName: 'vscs',
            attributeType: NUAttribute.ATTR_TYPE_LIST,
            description: `List of controllers associated with the nsg`,
            isReadOnly: true,
            subType: NUVSC,
            userlabel: `Vscs`,
        }),
        nsginfo: new NUAttribute({
            localName: 'nsginfo',
            attributeType: NUAttribute.ATTR_TYPE_STRING,
            description: `An embedded object from the nsinfo entity from VSD. Contains info such as software version, CPU type, BIOS version etc. The embedded object is returned in JSON format`,
            isReadOnly: true,
            userlabel: `Nsginfo`,
        }),
        nsgstate: new NUAttribute({
            localName: 'nsgstate',
            attributeType: NUAttribute.ATTR_TYPE_STRING,
            description: `Information from the NSGState object in VSD in JSON format. Contains information about connection status, TPM status, operation mode etc.`,
            isReadOnly: true,
            userlabel: `Nsgstate`,
        }),
        nsgsummary: new NUAttribute({
            localName: 'nsgsummary',
            attributeType: NUAttribute.ATTR_TYPE_STRING,
            description: `NSG summary in JSON format - contains alarm counts, locality, bootstrap info etc.`,
            isReadOnly: true,
            userlabel: `Nsgsummary`,
        }),
    }

    static getClassName() {
        return 'NUNSGatewayMonitor';
    }
    
    static getAllowedJobCommands() {
        return [];
    }
    
    static supportsAlarms() {
        return false;
    }
    
    static getInstanceFromID(ID) {
        const instance = new NUNSGatewayMonitor();
        instance.ID = ID;
        return instance;
    }
    
    get RESTName() {
        return 'nsgatewaysmonitor';
    }
    
    get resourceName() {
        return 'nsgatewaysmonitors';
    }
    
    getClassName() {
        return NUNSGatewayMonitor.getClassName();
    }

    getAllowedJobCommands() {
        return NUNSGatewayMonitor.getAllowedJobCommands();
    }
}

ServiceClassRegistry.register(NUNSGatewayMonitor);
````