### PR TITLE
vspk-javascript: generate locale file for every enum

### DIFF
--- a/monolithe/generators/lang/javascript/templates/locale_enum.json.tpl
+++ b/monolithe/generators/lang/javascript/templates/locale_enum.json.tpl
@@ -1,0 +1,7 @@
+{
+    "{{ class_prefix }}{{ enum_name }}": {
+        {%- for choice in allowed_choices %}
+        "{{ choice }}": "{{ choice }}"{% if not loop.last %},{% endif %}{% endfor %}
+    }
+}
+

--- a/monolithe/generators/lang/javascript/writers/apiversionwriter.py
+++ b/monolithe/generators/lang/javascript/writers/apiversionwriter.py
@@ -20,6 +20,7 @@ class APIVersionWriter(TemplateFileWriter):
         self.abstract_directory =  "%s/abstract" % self.model_directory
         self.enum_directory =  "%s/enums" % self.model_directory
         self.locale_directory = "%s/javascript/%s/locales/en" % (output, api_info["version"])
+        self.enum_locale_directory = "%s/enums" % self.locale_directory
 
         if os.path.exists(self.model_directory):
             shutil.rmtree(self.model_directory)
@@ -244,6 +245,13 @@ class APIVersionWriter(TemplateFileWriter):
                         class_prefix = self._class_prefix,
                         enum_name = enum_name,
                         allowed_choices = set(attribute.allowed_choices))
+            enum_locale_filename = "%s%s.json" % (self._class_prefix, enum_name)
+            self.write(destination = self.enum_locale_directory,
+                       filename=enum_locale_filename,
+                       template_name="locale_enum.json.tpl",
+                       class_prefix = self._class_prefix,
+                       enum_name = enum_name,
+                       allowed_choices = sorted(attribute.allowed_choices))
 
     def _write_generic_enums(self):
         """ This method generates generic enum classes.


### PR DESCRIPTION
Sample generated file content:
```
{
    "NUGatewayPersonalityEnum": {
        "DC7X50": "DC7X50",
        "EVDF": "EVDF",
        "EVDFB": "EVDFB",
        "HARDWARE_VTEP": "HARDWARE_VTEP",
        "NETCONF_7X50": "NETCONF_7X50",
        "NETCONF_THIRDPARTY_HW_VTEP": "NETCONF_THIRDPARTY_HW_VTEP",
        "NUAGE_210_WBX_32_Q": "NUAGE_210_WBX_32_Q",
        "NUAGE_210_WBX_48_S": "NUAGE_210_WBX_48_S",
        "OTHER": "OTHER",
        "VDFG": "VDFG",
        "VRSB": "VRSB",
        "VRSG": "VRSG",
        "VSA": "VSA",
        "VSG": "VSG"
    }
}
```