### PR TITLE
Changes to include supportsDeploymentFailures

### DIFF
--- a/monolithe/generators/lang/javascript/templates/entity.js.tpl
+++ b/monolithe/generators/lang/javascript/templates/entity.js.tpl
@@ -26,7 +26,9 @@ export default class {{ class_prefix }}{{ specification.entity_name }} extends {
         super(...args);
         this.defineProperties({
         {%- if specification.template %}
-            isTemplate: true,{% endif -%}    
+            isTemplate: true,{% endif -%}
+        {%- if specification.supportsDeploymentFailures %}
+            hasDeploymentFailures: false,{% endif -%}
         {%- for attribute in specification.attributes_modified %}
             {% set is_enum = attribute.allowed_choices and attribute.allowed_choices|length > 0  -%}
             {% set is_enum_list = is_enum and attribute.local_type == "list" and attribute.default_value -%}

--- a/monolithe/generators/lang/javascript/templates/entity.js.tpl
+++ b/monolithe/generators/lang/javascript/templates/entity.js.tpl
@@ -84,7 +84,14 @@ export default class {{ class_prefix }}{{ specification.entity_name }} extends {
     }
     
     {% endif -%}
-    
+
+    {% if specification.supportsDeploymentFailures -%}
+    static supportsDeploymentFailures() {
+        return true;
+    }
+
+    {% endif -%}
+
     static getInstanceFromID(ID) {
         const instance = new {{ class_prefix }}{{ specification.entity_name }}();
         instance.ID = ID;

--- a/monolithe/generators/lang/javascript/writers/apiversionwriter.py
+++ b/monolithe/generators/lang/javascript/writers/apiversionwriter.py
@@ -156,6 +156,8 @@ class APIVersionWriter(TemplateFileWriter):
         
         specification.supportsPermissions = len(filter(lambda child_api : child_api.rest_name == "enterprisepermission" or child_api.rest_name == "permission", specification.child_apis)) > 0
 
+        specification.supportsDeploymentFailures = len(filter(lambda child_api : child_api.rest_name == "deploymentfailure", specification.child_apis)) == 1
+
         filename = "%s%s.js" % (self._class_prefix, specification.entity_name)
 
         self.model_list.append("%s%s" %(self._class_prefix, specification.entity_name))


### PR DESCRIPTION
- will be included only in model classes that support deployment failures (similar to how supportsPermissions is added)
- Sample generated code:
```
import NUAttribute from 'service/NUAttribute';
import ServiceClassRegistry from 'service/ServiceClassRegistry';
import NUEntity from 'service/NUEntity';


/* Represents EgressProfile entity
   An Egress Profile represents an aggregation of IP, MAC and egress QoS profiles that are applied
   on a VPort instance.
*/
export default class NUEgressProfile extends NUEntity {
    constructor(...args) {
        super(...args);
        this.defineProperties({
            name: undefined,
            description: undefined,
            assocEntityType: undefined,
            associatedIPFilterProfileID: undefined,
            associatedIPFilterProfileName: undefined,
            associatedIPv6FilterProfileID: undefined,
            associatedIPv6FilterProfileName: undefined,
            associatedMACFilterProfileID: undefined,
            associatedMACFilterProfileName: undefined,
            associatedSAPEgressQoSProfileID: undefined,
            associatedSAPEgressQoSProfileName: undefined,
        });
    }

    static entityDescriptor = {
        description: `An Egress Profile represents an aggregation of IP, MAC and egress QoS profiles that are applied on a VPort instance.`,
        userlabel: `Egress Profile`,
    }

    static attributeDescriptors = {
        ...NUEntity.attributeDescriptors,
        name: new NUAttribute({
            localName: 'name',
            attributeType: NUAttribute.ATTR_TYPE_STRING,
            description: `A customer friendly name for the Egress Profile entity.`,
            canOrder: true,
            canSearch: true,
            userlabel: `Name`,
        }),
        description: new NUAttribute({
            localName: 'description',
            attributeType: NUAttribute.ATTR_TYPE_STRING,
            description: `A customer friendly description of the Egress Profile entity.`,
            canSearch: true,
            userlabel: `Description`,
        }),
        assocEntityType: new NUAttribute({
            localName: 'assocEntityType',
            attributeType: NUAttribute.ATTR_TYPE_STRING,
            description: `Type of parent entity`,
            isReadOnly: true,
            userlabel: `Associated Entity Type`,
        }),
        associatedIPFilterProfileID: new NUAttribute({
            localName: 'associatedIPFilterProfileID',
            attributeType: NUAttribute.ATTR_TYPE_STRING,
            description: `UUID of the associated IP Filter Profile entity.`,
            canOrder: true,
            canSearch: true,
            userlabel: `IP Filter Profile`,
        }),
        associatedIPFilterProfileName: new NUAttribute({
            localName: 'associatedIPFilterProfileName',
            attributeType: NUAttribute.ATTR_TYPE_STRING,
            description: `Name of the associated IP Filter Profile entity.`,
            isReadOnly: true,
            canOrder: true,
            canSearch: true,
            userlabel: `IP Filter Profile Name`,
        }),
        associatedIPv6FilterProfileID: new NUAttribute({
            localName: 'associatedIPv6FilterProfileID',
            attributeType: NUAttribute.ATTR_TYPE_STRING,
            description: `UUID of the associated IPv6 Filter Profile entity.`,
            canOrder: true,
            canSearch: true,
            userlabel: `IPv6 Filter Profile`,
        }),
        associatedIPv6FilterProfileName: new NUAttribute({
            localName: 'associatedIPv6FilterProfileName',
            attributeType: NUAttribute.ATTR_TYPE_STRING,
            description: `Name of the associated IPv6 Filter Profile entity.`,
            isReadOnly: true,
            canOrder: true,
            canSearch: true,
            userlabel: `IPv6 Filter Profile Name`,
        }),
        associatedMACFilterProfileID: new NUAttribute({
            localName: 'associatedMACFilterProfileID',
            attributeType: NUAttribute.ATTR_TYPE_STRING,
            description: `UUID of the associated MAC Filter Profile entity.`,
            canOrder: true,
            canSearch: true,
            userlabel: `MAC Filter Profile`,
        }),
        associatedMACFilterProfileName: new NUAttribute({
            localName: 'associatedMACFilterProfileName',
            attributeType: NUAttribute.ATTR_TYPE_STRING,
            description: `Name of the associated MAC Filter Profile entity.`,
            isReadOnly: true,
            canOrder: true,
            canSearch: true,
            userlabel: `MAC Filter Profile Name`,
        }),
        associatedSAPEgressQoSProfileID: new NUAttribute({
            localName: 'associatedSAPEgressQoSProfileID',
            attributeType: NUAttribute.ATTR_TYPE_STRING,
            description: `UUID of the associated SAP Egress QoS Profile entity.`,
            canOrder: true,
            canSearch: true,
            userlabel: `SAP Egress QoS Profile`,
        }),
        associatedSAPEgressQoSProfileName: new NUAttribute({
            localName: 'associatedSAPEgressQoSProfileName',
            attributeType: NUAttribute.ATTR_TYPE_STRING,
            description: `Name of the associated SAP Egress QoS Profile entity.`,
            isReadOnly: true,
            canOrder: true,
            canSearch: true,
            userlabel: `SAP Egress QoS Profile Name`,
        }),
    }

    static getClassName() {
        return 'NUEgressProfile';
    }
    
    static getAllowedJobCommands() {
        return [];
    }
    
    static supportsAlarms() {
        return false;
    }
    
    static supportsDeploymentFailures() {
        return true;
    }

    static getInstanceFromID(ID) {
        const instance = new NUEgressProfile();
        instance.ID = ID;
        return instance;
    }
    
    get RESTName() {
        return 'egressprofile';
    }
    
    get resourceName() {
        return 'egressprofiles';
    }
    
    getClassName() {
        return NUEgressProfile.getClassName();
    }

    getAllowedJobCommands() {
        return NUEgressProfile.getAllowedJobCommands();
    }
}

```