### PR TITLE
Issue with translation of the enableDHCPv4 and enableDHCPv6 on python

### DIFF
--- a/monolithe/generators/lang/python/converter.py
+++ b/monolithe/generators/lang/python/converter.py
@@ -38,8 +38,8 @@ def _string_clean(string):
         "VPort": "Vport",
         "IPv6": "Ipv6",
         "IPv4": "Ipv4",
-        "DHCPv4": "DhcpV4",
-        "DHCPv6": "DhcpV6"
+        "DHCPv4": "Dhcpv4",
+        "DHCPv6": "Dhcpv6"
     }
 
     rep = dict((re.escape(k), v) for k, v in rep.items())

--- a/monolithe/generators/lang/python/converter.py
+++ b/monolithe/generators/lang/python/converter.py
@@ -37,7 +37,9 @@ def _string_clean(string):
         "vCenter": "Vcenter",
         "VPort": "Vport",
         "IPv6": "Ipv6",
-        "IPv4": "Ipv4"
+        "IPv4": "Ipv4",
+        "DHCPv4": "DhcpV4",
+        "DHCPv6": "DhcpV6"
     }
 
     rep = dict((re.escape(k), v) for k, v in rep.items())


### PR DESCRIPTION
on vspk 0.0:
enableDHCPv4 was translated as enable_dhc_pv4
enableDHCPv6 was translated as enable_dhc_pv6