### PR TITLE
handle dataType time

### DIFF
--- a/monolithe/generators/lang/javascript/templates/entity.js.tpl
+++ b/monolithe/generators/lang/javascript/templates/entity.js.tpl
@@ -49,7 +49,7 @@ export default class {{ class_prefix }}{{ specification.entity_name }} extends {
         {% set type_object_or_list_with_subtype = ((attribute.local_type == "object" and attribute.subtype  and attribute.subtype != "JSON") or (attribute.local_type == "list" and attribute.subtype and attribute.subtype in subtypes_for_import)) -%}
         {{ attribute.name }}: new {{ class_prefix }}Attribute({
             localName: '{{ attribute.name }}',
-            attributeType: {{ class_prefix }}Attribute.ATTR_TYPE_{% if attribute.local_type == "integer" %}INTEGER{% elif attribute.local_type == "object" %}OBJECT{% elif attribute.local_type == "float" %}FLOAT{% elif attribute.local_type == "list" %}LIST{% elif attribute.local_type == "boolean" %}BOOLEAN{% elif attribute.local_type == "enum" and attribute.allowed_choices and attribute.allowed_choices|length > 0 %}ENUM{% else %}STRING{% endif %}{% if attribute.description %},
+            attributeType: {{ class_prefix }}Attribute.ATTR_TYPE_{% if attribute.local_type == "time" %}TIMESTAMP{% elif attribute.local_type == "integer" %}INTEGER{% elif attribute.local_type == "object" %}OBJECT{% elif attribute.local_type == "float" %}FLOAT{% elif attribute.local_type == "list" %}LIST{% elif attribute.local_type == "boolean" %}BOOLEAN{% elif attribute.local_type == "enum" and attribute.allowed_choices and attribute.allowed_choices|length > 0 %}ENUM{% else %}STRING{% endif %}{% if attribute.description %},
             description: `{{ attribute.description }}`{% endif %}{% if attribute.required %},
             isRequired: true{% endif %}{% if attribute.unique %},
             isUnique: true{% endif %}{% if attribute.creation_only %},


### PR DESCRIPTION
- NSG assign to pending ZFBRequest was failing. Root cause was form validation failure due to data type mismatch. zfbrequest.lastConnectedTime was of type `time` in api-spec, but generated code was treating it as string
- Now treating type of such attributes as `NUAttribute.ATTR_TYPE_TIMESTAMP`
- Impacted classes `NUEventLog, NUGroup, NUIKECertificate, NULicense, NUVCenterHypervisor,` and `NUZFBRequest`

Sample generated attribute code:
```
        lastConnectedTime: new NUAttribute({
            localName: 'lastConnectedTime',
            attributeType: NUAttribute.ATTR_TYPE_TIMESTAMP,
            description: `The time in which the last GET was made from the gateway.`,
            canOrder: true,
            canSearch: true,
            userlabel: `Last Connected Time`,
        }),
```