### PR TITLE
Disable supportsPermissions on template specifications

### DIFF
--- a/monolithe/generators/lang/javascript/writers/apiversionwriter.py
+++ b/monolithe/generators/lang/javascript/writers/apiversionwriter.py
@@ -133,7 +133,7 @@ class APIVersionWriter(TemplateFileWriter):
             
         specification.supportsAlarms = len(filter(lambda child_api : child_api.rest_name == "alarm", specification.child_apis)) == 1
         
-        specification.supportsPermissions = len(filter(lambda child_api : child_api.rest_name == "enterprisepermission" or child_api.rest_name == "permission", specification.child_apis)) > 0
+        specification.supportsPermissions = (not specification.template) and len(filter(lambda child_api : child_api.rest_name == "enterprisepermission" or child_api.rest_name == "permission", specification.child_apis)) > 0
 
         specification.supportsDeploymentFailures = len(filter(lambda child_api : child_api.rest_name == "deploymentfailure", specification.child_apis)) == 1
 


### PR DESCRIPTION
- do not support permissions if it is a template entity
- The following 12 files are impacted
```
$ diff --brief -r codegen codegen-base
codegen/javascript/6/models/NUDomainTemplate.js
codegen/javascript/6/models/NUGatewayTemplate.js
codegen/javascript/6/models/NUL2DomainTemplate.js
codegen/javascript/6/models/NUNSGatewayTemplate.js
codegen/javascript/6/models/NUNSPortTemplate.js
codegen/javascript/6/models/NUOverlayMirrorDestinationTemplate.js
codegen/javascript/6/models/NUPolicyGroupTemplate.js
codegen/javascript/6/models/NUPortTemplate.js
codegen/javascript/6/models/NURedirectionTargetTemplate.js
codegen/javascript/6/models/NUSubnetTemplate.js
codegen/javascript/6/models/NUVLANTemplate.js
codegen/javascript/6/models/NUZoneTemplate.js
```
The below function will not be generated anymore for the above. This is used to add permission child editor in ModuleContext.

<img width="1440" alt="Screen Shot 2020-08-05 at 4 07 40 PM" src="https://user-images.githubusercontent.com/24920919/89472680-d2513f80-d735-11ea-8bf0-b4c8697302a8.png">

