### PR TITLE
fix addressOverrideType enum generation

### DIFF
--- a/monolithe/generators/lang/javascript/config/config.json
+++ b/monolithe/generators/lang/javascript/config/config.json
@@ -19,6 +19,7 @@
         "egressauditaclentrytemplate": ["addressOverrideType"],
         "egressdomainfloatingipaclentrytemplate": ["addressOverrideType"],
         "ingressaclentrytemplate": ["addressOverrideType"],
-        "ingressauditaclentrytemplate": ["addressOverrideType"]    },
+        "ingressauditaclentrytemplate": ["addressOverrideType"]
+    },
     "list_subtypes_generic": ["double", "enum", "long", "string", "JSON"]
 }

--- a/monolithe/generators/lang/javascript/config/config.json
+++ b/monolithe/generators/lang/javascript/config/config.json
@@ -13,7 +13,12 @@
         "nsgateway": ["TPMStatus"],
         "ingressadvfwdentrytemplate": ["appType", "addressOverrideType"],
         "link": ["acceptanceCriteria"],
-        "vnf": ["allowedActions", "lastUserAction"]
-    },
+        "vnf": ["allowedActions", "lastUserAction"],
+        "egressaclentrytemplate": ["addressOverrideType"],
+        "egressadvfwdentrytemplate": ["addressOverrideType"],
+        "egressauditaclentrytemplate": ["addressOverrideType"],
+        "egressdomainfloatingipaclentrytemplate": ["addressOverrideType"],
+        "ingressaclentrytemplate": ["addressOverrideType"],
+        "ingressauditaclentrytemplate": ["addressOverrideType"]    },
     "list_subtypes_generic": ["double", "enum", "long", "string", "JSON"]
 }


### PR DESCRIPTION
- This is to fix incorrect enum type generation for addressOverrideType attribute

**Before:**
```
addressOverrideType: new NUAttribute({
            localName: 'addressOverrideType',
            attributeType: NUAttribute.ATTR_TYPE_ENUM,
            description: `AddressOverride Type - either IPv4 or IPv6 or MACRO_GROUP. Possible values are IPV4, IPV6 and MACRO_GROUP.`,
            canOrder: true,
            canSearch: true,
            choices: [NUIPTypeEnum.IPV4, NUIPTypeEnum.IPV6, NUIPTypeEnum.MACRO_GROUP],
            userlabel: `Address Override Type`,
        }),
```

**After:**
```
addressOverrideType: new NUAttribute({
            localName: 'addressOverrideType',
            attributeType: NUAttribute.ATTR_TYPE_ENUM,
            description: `AddressOverride Type - either IPv4 or IPv6 or MACRO_GROUP. Possible values are IPV4, IPV6 and MACRO_GROUP.`,
            canOrder: true,
            canSearch: true,
            choices: [NUEgressAuditACLEntryTemplateAddressOverrideTypeEnum.IPV4,
                NUEgressAuditACLEntryTemplateAddressOverrideTypeEnum.IPV6,
                NUEgressAuditACLEntryTemplateAddressOverrideTypeEnum.MACRO_GROUP],
            userlabel: `Address Override Type`,
        }),
```

- If enum values for an attribute are part of generic enum values, then generic enum type is used for the attribute, https://github.com/nuagenetworks/monolithe/blob/master/monolithe/generators/lang/javascript/writers/apiversionwriter.py#L162
- In corner cases such as addressOverrideType, we cannot have IPType.MACRO_GROUP. For such attributes we specify an override in config.json such that generic type is not used